### PR TITLE
Removed the step to download and install npp.

### DIFF
--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -579,17 +579,11 @@ Resources:
             'c:\cfn\assets\GoogleChromeStandaloneEnterprise64.msi':
               source: >-
                 https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi
-            'c:\cfn\assets\npp.Installer.x64.exe':
-              source: >-
-                https://notepad-plus-plus.org/repository/7.x/7.5.9/npp.7.5.9.Installer.x64.exe
           commands:
             a-install-aws-cli:
               command: 'start /wait c:\cfn\assets\AWSCLI64PY3.msi /quiet /passive /qn'
               waitAfterCompletion: '0'
-            b-install-npp:
-              command: 'start /wait c:\cfn\assets\npp.Installer.x64.exe /S'
-              waitAfterCompletion: '0'
-            c-install-chrome:
+            b-install-chrome:
               command: >-
                 start /wait c:\cfn\assets\GoogleChromeStandaloneEnterprise64.msi
                 /quiet /passive


### PR DESCRIPTION
The link to the n++ installer is no longer valid and returns a 404 status. Removed step as this will happen again in the future if we only update the link.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
