### PR TITLE
Linux version with new PAC demo and 5.0PU05 AMIs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "submodules/quickstart-aws-vpc"]
 	path = submodules/quickstart-aws-vpc
-	url = ../../aws-quickstart/quickstart-aws-vpc.git
+	url = git@github.com:aws-quickstart/quickstart-aws-vpc.git
 	branch = master
 [submodule "submodules/quickstart-microsoft-rdgateway"]
 	path = submodules/quickstart-microsoft-rdgateway
-	url = ../../aws-quickstart/quickstart-microsoft-rdgateway.git
+	url = git@github.com:aws-quickstart/quickstart-microsoft-rdgateway.git
 	branch = master
 [submodule "submodules/quickstart-microsoft-utilities"]
 	path = submodules/quickstart-microsoft-utilities
-	url = ../../aws-quickstart/quickstart-microsoft-utilities.git
+	url = git@github.com:aws-quickstart/quickstart-microsoft-utilities.git
+	branch = master
+[submodule "submodules/quickstart-linux-bastion"]
+	path = submodules/quickstart-linux-bastion
+	url = git@github.com:aws-quickstart/quickstart-linux-bastion.git
 	branch = master

--- a/ci/quickstart-microfocus-amc-es-input-linux-full.json
+++ b/ci/quickstart-microfocus-amc-es-input-linux-full.json
@@ -1,0 +1,235 @@
+[
+    {
+        "ParameterKey": "AdditionalESStorageinGiB",
+        "ParameterValue": "1024"
+    },
+    {
+        "ParameterKey": "AvailabilityZones",
+        "ParameterValue": "$[taskcat_genaz_2]"
+    },
+    {
+        "ParameterKey": "DatabaseType",
+        "ParameterValue": "Create-RDS-Remote-Database"
+    },
+    {
+        "ParameterKey": "DBBackupRetentionPeriod",
+        "ParameterValue": "30"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.r4.large"
+    },
+    {
+        "ParameterKey": "DBMasterUsername",
+        "ParameterValue": "DBAdmin"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "DBMasterUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_DBMasterUserPassword]"
+    },
+    {
+        "ParameterKey": "DBPreferredBackupWindow",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "DBPreferredMaintenanceWindow",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "DSMicrosoftADEdition",
+        "ParameterValue": "Enterprise"
+    },
+    {
+        "ParameterKey": "DBStorageInGiB",
+        "ParameterValue": "1024"
+    },
+    {
+        "ParameterKey": "DemoAppsIngressCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "DeployMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DomainAdminPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "DomainAdminPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_DomainAdminPassword]"
+    },
+    {
+        "ParameterKey": "DomainDNSName",
+        "ParameterValue": "example.com" 
+    },
+    {
+        "ParameterKey": "DomainNetBIOSName",
+        "ParameterValue": "example"
+    },
+    {
+        "ParameterKey": "ESCWLogGroupRetentionInDays",
+        "ParameterValue": "7"
+    },
+    {
+        "ParameterKey": "ESDemoUserPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "ESDemoUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_ESDemoUserPassword]"
+    },
+    {
+        "ParameterKey": "ESInstanceType",
+        "ParameterValue": "c5.large"
+    },
+    {
+        "ParameterKey": "ESLicenseFilename",
+        "ParameterValue": "overridden"
+
+    },
+    {
+        "ParameterKey": "ESResourceNamePrefix",
+        "ParameterValue": "AWS::StackName"
+    },
+    {
+        "ParameterKey": "FSInstanceType",
+        "ParameterValue": "c5.large"
+    },
+    {
+        "ParameterKey": "FSStorageInGiB",
+        "ParameterValue": "50"
+    },
+    {
+        "ParameterKey": "FileshareType",
+        "ParameterValue": "Create-Remote-Fileshare-Server"
+    },
+    {
+        "ParameterKey": "FSVIEWUserPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "FSVIEWUserPasswordConfirm",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "InstallFSDemoApp",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "InstallSQLDemoApp",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "cikey"
+    },
+    {
+        "ParameterKey": "LicenseAgreement",
+        "ParameterValue": "I agree"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountName",
+        "ParameterValue": "MFDSServiceAccount"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_MFDSServiceAccountPassword]"
+    },
+    {
+        "ParameterKey": "NumberOfRDGWHosts",
+        "ParameterValue": "1"
+    },
+    {
+        "ParameterKey": "OperatorEmail",
+        "ParameterValue": "None"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1ACIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2ACIDR",
+        "ParameterValue": "10.0.32.0/19"
+    },
+    {
+        "ParameterKey": "PublicSubnet1CIDR",
+        "ParameterValue": "10.0.128.0/20"
+    },
+    {
+        "ParameterKey": "PublicSubnet2CIDR",
+        "ParameterValue": "10.0.144.0/20"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-microfocus-amc-es/"
+    },
+    {
+        "ParameterKey": "ESS3BucketName",
+        "ParameterValue": "$[taskcat_getval_QSS3BucketName]"
+    },
+    {
+        "ParameterKey": "RDGWCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "RDGWInstanceType",
+        "ParameterValue": "t2.large"
+    },
+    {
+        "ParameterKey": "RegionsPerInstance",
+        "ParameterValue": "1"
+    },
+	{
+        "ParameterKey": "NumberOfBastionHosts",
+        "ParameterValue": "1"
+    },
+	{
+        "ParameterKey": "BastionInstanceType",
+        "ParameterValue": "t2.large"
+    },
+	{
+        "ParameterKey": "InstallPACDemoApp",
+        "ParameterValue": "true"
+    },
+	{
+        "ParameterKey": "PACDBInstanceClass",
+        "ParameterValue": "db.r4.large"
+    },
+	{
+        "ParameterKey": "PACDBMasterUsername",
+        "ParameterValue": "DBAdmin"
+    },
+    {
+        "ParameterKey": "PACDBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "PACDBMasterUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_PACDBMasterUserPassword]"
+    },
+	{
+        "ParameterKey": "OS",
+        "ParameterValue": "Red Hat Enterprise Linux"
+    },
+	{
+        "ParameterKey": "BastionCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "VPCCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    }
+]

--- a/ci/quickstart-microfocus-amc-es-input-windows-full.json
+++ b/ci/quickstart-microfocus-amc-es-input-windows-full.json
@@ -1,0 +1,235 @@
+[
+    {
+        "ParameterKey": "AdditionalESStorageinGiB",
+        "ParameterValue": "1024"
+    },
+    {
+        "ParameterKey": "AvailabilityZones",
+        "ParameterValue": "$[taskcat_genaz_2]"
+    },
+    {
+        "ParameterKey": "DatabaseType",
+        "ParameterValue": "Create-RDS-Remote-Database"
+    },
+    {
+        "ParameterKey": "DBBackupRetentionPeriod",
+        "ParameterValue": "30"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.r4.large"
+    },
+    {
+        "ParameterKey": "DBMasterUsername",
+        "ParameterValue": "DBAdmin"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "DBMasterUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_DBMasterUserPassword]"
+    },
+    {
+        "ParameterKey": "DBPreferredBackupWindow",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "DBPreferredMaintenanceWindow",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "DSMicrosoftADEdition",
+        "ParameterValue": "Enterprise"
+    },
+    {
+        "ParameterKey": "DBStorageInGiB",
+        "ParameterValue": "1024"
+    },
+    {
+        "ParameterKey": "DemoAppsIngressCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "DeployMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DomainAdminPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "DomainAdminPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_DomainAdminPassword]"
+    },
+    {
+        "ParameterKey": "DomainDNSName",
+        "ParameterValue": "example.com" 
+    },
+    {
+        "ParameterKey": "DomainNetBIOSName",
+        "ParameterValue": "example"
+    },
+    {
+        "ParameterKey": "ESCWLogGroupRetentionInDays",
+        "ParameterValue": "7"
+    },
+    {
+        "ParameterKey": "ESDemoUserPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "ESDemoUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_ESDemoUserPassword]"
+    },
+    {
+        "ParameterKey": "ESInstanceType",
+        "ParameterValue": "c5.large"
+    },
+    {
+        "ParameterKey": "ESLicenseFilename",
+        "ParameterValue": "overridden"
+
+    },
+    {
+        "ParameterKey": "ESResourceNamePrefix",
+        "ParameterValue": "AWS::StackName"
+    },
+    {
+        "ParameterKey": "FSInstanceType",
+        "ParameterValue": "c5.large"
+    },
+    {
+        "ParameterKey": "FSStorageInGiB",
+        "ParameterValue": "50"
+    },
+    {
+        "ParameterKey": "FileshareType",
+        "ParameterValue": "Create-Remote-Fileshare-Server"
+    },
+    {
+        "ParameterKey": "FSVIEWUserPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "FSVIEWUserPasswordConfirm",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "InstallFSDemoApp",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "InstallSQLDemoApp",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "cikey"
+    },
+    {
+        "ParameterKey": "LicenseAgreement",
+        "ParameterValue": "I agree"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountName",
+        "ParameterValue": "MFDSServiceAccount"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountPassword",
+        "ParameterValue": "Password123!"
+    },
+    {
+        "ParameterKey": "MFDSServiceAccountPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_MFDSServiceAccountPassword]"
+    },
+    {
+        "ParameterKey": "NumberOfRDGWHosts",
+        "ParameterValue": "1"
+    },
+    {
+        "ParameterKey": "OperatorEmail",
+        "ParameterValue": "None"
+    },
+    {
+        "ParameterKey": "PrivateSubnet1ACIDR",
+        "ParameterValue": "10.0.0.0/19"
+    },
+    {
+        "ParameterKey": "PrivateSubnet2ACIDR",
+        "ParameterValue": "10.0.32.0/19"
+    },
+    {
+        "ParameterKey": "PublicSubnet1CIDR",
+        "ParameterValue": "10.0.128.0/20"
+    },
+    {
+        "ParameterKey": "PublicSubnet2CIDR",
+        "ParameterValue": "10.0.144.0/20"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-microfocus-amc-es/"
+    },
+    {
+        "ParameterKey": "ESS3BucketName",
+        "ParameterValue": "$[taskcat_getval_QSS3BucketName]"
+    },
+    {
+        "ParameterKey": "RDGWCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "RDGWInstanceType",
+        "ParameterValue": "t2.large"
+    },
+    {
+        "ParameterKey": "RegionsPerInstance",
+        "ParameterValue": "1"
+    },
+	{
+        "ParameterKey": "NumberOfBastionHosts",
+        "ParameterValue": "1"
+    },
+	{
+        "ParameterKey": "BastionInstanceType",
+        "ParameterValue": "t2.large"
+    },
+	{
+        "ParameterKey": "InstallPACDemoApp",
+        "ParameterValue": "true"
+    },
+	{
+        "ParameterKey": "PACDBInstanceClass",
+        "ParameterValue": "db.r4.large"
+    },
+	{
+        "ParameterKey": "PACDBMasterUsername",
+        "ParameterValue": "DBAdmin"
+    },
+    {
+        "ParameterKey": "PACDBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_12A]"
+    },
+    {
+        "ParameterKey": "PACDBMasterUserPasswordConfirm",
+        "ParameterValue": "$[taskcat_getval_PACDBMasterUserPassword]"
+    },
+	{
+        "ParameterKey": "OS",
+        "ParameterValue": "Windows"
+    },
+	{
+        "ParameterKey": "BastionCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    },
+    {
+        "ParameterKey": "VPCCIDR",
+        "ParameterValue": "10.0.0.0/16"
+    }
+]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -3,8 +3,8 @@ global:
   owner: chris.turner@microfocus.com
   qsname: quickstart-microfocus-amc-es
   regions:
-    - ap-northeast-1  # Asia Pacific (Tokyo)
-    - ap-northeast-2  # Asia Pacific (Seoul)
+          #    - ap-northeast-1  # Asia Pacific (Tokyo)
+          #    - ap-northeast-2  # Asia Pacific (Seoul)
 #    - ap-south-1      # Asia Pacific (Mumbai) --> RDS-WinAuth not supported 2019-01-01
     - ap-southeast-1  # Asia Pacific (Singapore)
 #    - ap-southeast-2  # Asia Pacific (Sydney) --> Skipped since m5/c5.large not available in ap-southeast-2a)
@@ -22,56 +22,38 @@ global:
   reporting: true
 
 tests:
-  # Full: FS & DB
-  master-fs-db:
-    parameter_input: quickstart-microfocus-amc-es-input-full.json
+  # Full: FS & DB (Linux)
+  master-linux-fs-db:
+    parameter_input: quickstart-microfocus-amc-es-input-linux-full.json
     template_file: mf-es-master-template.yaml
     regions:
-#      - us-east-1       # US East (N. Virginia)
-#      - us-east-2       # US East (Ohio)
-#      - us-west-1       # US West (N. California) --> RDS-WinAuth not supported 2019-01-01
-#      - us-west-2       # US West (Oregon)
-      - ca-central-1    # Canada (Central)
-      - eu-central-1    # EU (Frankfurt)
-      - eu-west-1       # EU (Ireland)
-#      - eu-west-2       # EU (London)
-#      - eu-west-3       # EU (Paris) --> DirSrv not supported 2019-01-01
-#      - eu-north-1      # EU (Stockholm) --> DirSrv not supported 2019-01-01
-#      - ap-northeast-1  # Asia Pacific (Tokyo)
-#      - ap-northeast-2  # Asia Pacific (Seoul)
-#      - ap-southeast-1  # Asia Pacific (Singapore)
-#      - ap-southeast-2  # Asia Pacific (Sydney) --> Skipped since m5/c5.large not available in ap-southeast-2a)
-#      - ap-south-1      # Asia Pacific (Mumbai) --> RDS-WinAuth not supported 2019-01-01
-#      - sa-east-1       # South America (São Paulo) --> RDS-WinAuth not supported 2019-01-01
+       # - us-east-2          # US East (Ohio)          --> Windows testing below
+       - us-east-1          # US East (N. Virginia)
+       # - us-west-1          # US West (N. California) --> RDS-WinAuth not supported 2020-Feb-07
+       - us-west-2          # US West (Oregon)
+       # - ap-east-1          # Asia Pacific (Hong Kong) --> MFES not available
+       # - ap-south-1         # Asia Pacific (Mumbai) --> RDS-WinAuth not supported 2020-Feb-07
+       # - ap-northeast-3     # Asia Pacific (Osaka-Local) --> Osaka-Local not supported, DirSrv not supported 2020-Feb-07
+       # - ap-northeast-2     # Asia Pacific (Seoul) --> Skip testing due to 'Failed to locate Availability Zone: ap-northeast-2b' issue
+       - ap-southeast-1     # Asia Pacific (Singapore)
+       - ap-southeast-2     # Asia Pacific (Sydney)
+       - ap-northeast-1     # Asia Pacific (Tokyo)
+       - ca-central-1       # Canada (Central)
+       # - cn-north-1         # China (Beijing) --> China not supported
+       # - cn-northwest-1     # China (Ningxia) --> China not supported
+       - eu-central-1       # Europe (Frankfurt)
+       - eu-west-1          # Europe (Ireland)
+       - eu-west-2          # Europe (London)
+       # - eu-west-3          # Europe (Paris) --> DirSrv not supported 2020-Feb-07
+       # - eu-north-1         # Europe (Stockholm) --> RDGW required t2.x no longer available
+       # - me-south-1         # Middle East (Bahrain) --> MFES not available, DirSrv not supported 2020-Feb-07
+       # - sa-east-1          # South America (Sao Paulo) --> RDS-WinAuth not supported 2020-Feb-07
+       # - us-gov-east-1      # AWS GovCloud (US-East) --> GovCloud not supported, RDS-WinAuth not supported 2020-Feb-07
+       # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported, RDS-WinAuth not supported 2020-Feb-07
 
-  # FS, No DB
-  master-fs-nodb:
-    parameter_input: quickstart-microfocus-amc-es-input-fs-nodb.json
+  # Full: FS & DB (Windows)
+  master-windows-fs-db:
+    parameter_input: quickstart-microfocus-amc-es-input-windows-full.json
     template_file: mf-es-master-template.yaml
     regions:
-      - us-west-1       # US West (N. California)
-#      - us-west-2       # US West (Oregon)
-#      - ca-central-1    # Canada (Central)
-      - ap-south-1      # Asia Pacific (Mumbai)
-      - ap-southeast-2
-
-  # DB, No FS
-  master-db-nofs:
-    parameter_input: quickstart-microfocus-amc-es-input-db-nofs.json
-    template_file: mf-es-master-template.yaml
-    regions:
-      - eu-central-1    # EU (Frankfurt)
-      - eu-west-1       # EU (Ireland)
-      - eu-west-2       # EU (London)
-#      - ap-northeast-1  # Asia Pacific (Tokyo)
-#      - ap-northeast-2  # Asia Pacific (Seoul)
-
-  # Minimal: No FS, No DB
-  master-nodb-nofs:
-    parameter_input: quickstart-microfocus-amc-es-input-nofs-nodb.json
-    template_file: mf-es-master-template.yaml
-    regions:
-      - ap-southeast-1  # Asia Pacific (Singapore)
-#      - ap-southeast-2  # Asia Pacific (Sydney) --> Skipped since m5/c5.large not available in ap-southeast-2a
       - us-east-2       # US East (Ohio)
-#      - sa-east-1       # South America (São Paulo) --> Skipped since NAT GW not available in sa-east-1a

--- a/scripts/Add-Other-MFDS.ps1
+++ b/scripts/Add-Other-MFDS.ps1
@@ -1,0 +1,69 @@
+param(
+    [Parameter(Mandatory = $True)]
+    [string]$DomainNetBIOSName,
+
+    [Parameter(Mandatory = $True)]
+    [string]$ServiceUser,
+
+    [Parameter(Mandatory = $True)]
+    [string]$ServicePassword
+)
+try {
+    $ErrorActionPreference = "Stop"
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    Write-Host "Deleting MFDS Service"
+    Stop-Service -Name "MF_CCITCP2"
+    $Service=gwmi win32_service -filter "Name='MF_CCITCP2'"
+    $Service.delete()
+
+    function addDS {
+
+        Param
+        (
+            [Parameter(Mandatory = $true)]
+            [string] $HostName,
+            [Parameter(Mandatory = $true)]
+            [string] $Port,
+            [Parameter(Mandatory = $true)]
+            [string] $Name
+        )
+
+        $JMessage = '
+        {
+            \"MfdsHost\": \"' + $HostName + '\",
+            \"MfdsIdentifier\": \"' + $Name + '\",
+            \"MfdsPort\": \"' + $Port + '\"
+        }'
+
+        $RequestURL = 'http://localhost:10004/server/v1/config/mfds'
+        $Origin = 'Origin: http://localhost:10004'
+
+        curl.exe -sX POST $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin -d $Jmessage --cookie cookie.txt | Out-Null
+    }
+
+    Write-Host "Configuring ESCWA"
+    $JMessage = '{ \"mfUser\": \"\", \"mfPassword\": \"\" }'
+
+    $RequestURL = 'http://localhost:10004/logon'
+    $Origin = 'Origin: http://localhost:10004'
+
+    curl.exe -sX POST  $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin -d $Jmessage --cookie-jar cookie.txt | Out-Null
+
+    $RequestURL = 'http://localhost:10004/server/v1/config/mfds'
+    $headers = @{
+        'accept' = 'application/json'
+        'Content-Type' = 'application/json'
+        'X-Requested-With' = 'AgileDev'
+        'Origin' = 'http://localhost:10004'
+    }
+    $mfdsObj = Invoke-RestMethod -URI $RequestURL -headers $headers -method 'GET'
+    $Uid=$mfdsObj.Uid
+    $RequestURL = "http://localhost:10004/server/v1/config/mfds/$Uid"
+    curl.exe -sX DELETE $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin --cookie cookie.txt | Out-Null
+
+    addDS -HostName "ESSERVER1" -Name "ESSERVER1" -Port "86"
+    addDS -HostName "ESSERVER2" -Name "ESSERVER2" -Port "86"
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Add-region-to-PAC.ps1
+++ b/scripts/Add-region-to-PAC.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ESInstanceName
+)
+
+try {
+    $ErrorActionPreference = "Stop"
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    Write-Host "Configuring ESCWA"
+    #Logon to ESCWA
+    $JMessage = '{ \"mfUser\": \"\", \"mfPassword\": \"\" }'
+
+    $RequestURL = 'http://ESCWAInstance:10004/logon'
+    $Origin = 'Origin: http://ESCWAInstance:10004'
+
+    curl.exe -sX POST  $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin -d $Jmessage --cookie-jar cookie.txt | Out-Null
+    Write-Host "Adding to PAC"
+    if ($ESInstanceName -eq "ESSERVER1") {
+        $RegionName = "BNKDM"
+    }else {
+        $RegionName = "BNKDM2"
+    }
+    $RequestURL = 'http://ESCWAInstance:10004/native/v1/regions/' + $ESInstanceName + '/86/' + $RegionName
+    $JMessage = '
+        {
+            \"mfCASSOR\": \"' + ":ES_SCALE_OUT_REPOS_1=DemoPSOR=redis,ESRedis:6379##TMP" + '\",
+            \"mfCASPAC\": \"' + "DemoPAC" + '\",
+        }'
+    curl.exe -sX PUT $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin -d $Jmessage --cookie-jar cookie.txt | Out-Null
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Add-region-to-PAC.sh
+++ b/scripts/Add-region-to-PAC.sh
@@ -1,0 +1,26 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Add-region-to-PAC.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 2 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Add-region-to-PAC <ESInstanceName>"
+  exit 1
+fi
+
+ESInstanceName=$1
+RegionName=$2
+# Logon to ESCWA
+RequestURL='http://ESCWAInstance:10004/logon'
+Origin='Origin: http://ESCWAInstance:10004'
+Jmessage='{"mfUser":"","mfPassword":""}'
+curl -sX POST $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H "$Origin" -d "$Jmessage" --cookie-jar cookie.txt
+
+
+RequestURL="http://ESCWAInstance:10004/native/v1/regions/${ESInstanceName}/86/${RegionName}"
+echo $RequestURL
+Jmessage='{"mfCASSOR":":ES_SCALE_OUT_REPOS_1=DemoPSOR=redis,ESRedis:6379##TMP","mfCASPAC":"DemoPAC"}'
+echo $Jmessage
+curl -sX PUT $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H "$Origin" -d "$Jmessage" --cookie-jar cookie.txt

--- a/scripts/Add-user-to-admin-group.ps1
+++ b/scripts/Add-user-to-admin-group.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Username,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DomainDnsName,
+
+    [Parameter(Mandatory=$true)]
+    [String]$DomainUserName,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DomainUserPassword
+)
+
+try {
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    $ErrorActionPreference = "Stop";
+
+	# Get the domain (netbios name) and create domain admin credentials
+	$wmiDomain = Get-WmiObject Win32_NTDomain -Filter "DnsForestName = `"$DomainDnsName`""
+	$cred = New-Object System.Management.Automation.PSCredential `
+		-ArgumentList "$($wmiDomain.DomainName)\$DomainUserName", (ConvertTo-SecureString "$DomainUserPassword" -AsPlainText -Force);
+
+    Add-ADGroupMember -Identity "AWS delegated administrators" -Members $Username -Credential $cred
+
+} catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Configure-ESCWA.ps1
+++ b/scripts/Configure-ESCWA.ps1
@@ -1,0 +1,32 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$DomainNetBIOSName,
+    [Parameter(Mandatory=$true)]
+    [string]$ServiceUser,
+    [Parameter(Mandatory=$true)]
+    [string]$ServicePassword
+    
+)
+
+try {
+    $ErrorActionPreference = "Stop"
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    Write-Host "Updating ESCWA Service Properties"
+    Stop-Service -Name "ESCWA"
+    $Account="${DomainNetBIOSName}\${ServiceUser}"
+    $Service=gwmi win32_service -filter "Name='ESCWA'"
+    $Service.change($null,$null,$null,$null,$null,$false,$Account,$ServicePassword,$null,$null,$null)
+
+    $Directory = "C:\ProgramData\Micro Focus\Enterprise Developer\ESCWA"
+    $Inherit = [system.security.accesscontrol.InheritanceFlags]"ContainerInherit, ObjectInherit"
+    $Propagation = [system.security.accesscontrol.PropagationFlags]"None"
+    $Acl = Get-Acl $directory
+    $Accessrule = New-Object system.security.AccessControl.FileSystemAccessRule($Account,"FullControl", $inherit, $propagation, "Allow")
+    $Acl.AddAccessRule($Accessrule)
+    Set-Acl -aclobject $Acl $Directory
+    Start-Service -Name "ESCWA"
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Configure-ODBC.sh
+++ b/scripts/Configure-ODBC.sh
@@ -1,0 +1,22 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Configure-ODBC.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Configure-ODBC <Server>"
+  exit 1
+fi
+
+Server=$1
+
+cat <<EOT >> /tmp/odbc.ini
+[DBNASEDB]
+Driver = ODBC Driver 17 for SQL Server
+Server = $Server
+port = 1433
+Database = BANKDEMO
+EOT
+odbcinst -i -s -l -f /tmp/odbc.ini

--- a/scripts/Configure-PAC.ps1
+++ b/scripts/Configure-PAC.ps1
@@ -1,0 +1,52 @@
+try {
+    $ErrorActionPreference = "Stop"
+    Write-Host "Configuring ESCWA"
+    #Logon to ESCWA
+    $JMessage = '{ \"mfUser\": \"\", \"mfPassword\": \"\" }'
+
+    $RequestURL = 'http://localhost:10004/logon'
+    $Origin = 'Origin: http://localhost:10004'
+
+    curl.exe -sX POST  $RequestURL -H 'accept: application/json' -H 'X-Requested-With: AgileDev' -H 'Content-Type: application/json' -H $Origin -d $Jmessage --cookie-jar cookie.txt | Out-Null
+    function MakeRequest {
+        param (
+            [Parameter(Mandatory = $true)][string] $RequestURL,
+            [Parameter(Mandatory = $true)][string] $Jmessage
+        )
+        $headers = @{
+            'accept' = 'application/json'
+            'Content-Type' = 'application/json'
+            'X-Requested-With' = 'AgileDev'
+            'Origin' = 'http://localhost:10004'
+        }
+
+        $Response = Invoke-RestMethod -URI $RequestURL -headers $headers -body $Jmessage -method 'POST'
+        return $Response
+    }
+    #Create SOR
+    Write-Host "Creating SOR"
+    $RequestURL = 'http://localhost:10004/server/v1/config/groups/sors'
+    $JMessage = @{
+            "SorName" = "DemoPSOR"
+            "SorDescription" ="Demo SOR using redis"
+            "SorType" = "redis"
+            "SorConnectPath" = "ESRedis:6379"
+        }
+    $JMessage = $JMessage | ConvertTo-Json
+    $Response = MakeRequest -RequestURL $RequestURL -Jmessage $JMessage
+    $Uid = $Response.uid
+
+    Write-Host "Creating PAC"
+    $RequestURL = 'http://localhost:10004/server/v1/config/groups/pacs'
+    $JMessage = @{
+            "PacName" = "DemoPAC"
+            "PacDescription" = "Demo PAC"
+            "PacResourceSorUid" = "$Uid"
+        }
+    $JMessage = $JMessage | ConvertTo-Json
+    MakeRequest -RequestURL $RequestURL -Jmessage $JMessage
+
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Create-ps-DSN.sh
+++ b/scripts/Create-ps-DSN.sh
@@ -1,0 +1,54 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Create-ps-DSN.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Create-ps-DSN <DBMasterPassword>"
+  exit 1
+fi
+
+DBMasterPassword=$1
+cat <<EOT >> /tmp/odbcinst.ini
+[PostgreSQL]
+Driver = /usr/local/lib/psqlodbcw.so
+Setup = /usr/local/lib/libodbcpsqlS.so
+EOT
+odbcinst -i -d -f /tmp/odbcinst.ini
+
+cat <<EOT >> /tmp/odbc_ps.ini
+[PG.POSTGRES]
+Driver = PostgreSQL
+Servername = ESPACDatabase
+port = 5432
+Database = postgres
+Username = esuser
+Password = $DBMasterPassword
+
+[PG.VSAM]
+Driver = PostgreSQL
+Servername = ESPACDatabase
+port = 5432
+Database = MicroFocus\$SEE\$Files\$VSAM
+Username = esuser
+Password = $DBMasterPassword
+
+[PG.REGION]
+Driver = PostgreSQL
+Servername = ESPACDatabase
+port = 5432
+Database = MicroFocus\$CAS\$Region\$DEMOPAC
+Username = esuser
+Password = $DBMasterPassword
+
+[PG.CROSSREGION]
+Driver = PostgreSQL
+Servername = ESPACDatabase
+port = 5432
+Database = MicroFocus\$CAS\$CrossRegion
+Username = esuser
+Password = $DBMasterPassword
+EOT
+odbcinst -i -s -l -f /tmp/odbc_ps.ini

--- a/scripts/Install-ODBC.sh
+++ b/scripts/Install-ODBC.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Install-ODBC.log|logger -t user-data -s 2>/dev/console) 2>&1
+#RedHat Enterprise Server 7
+curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
+ACCEPT_EULA=Y yum install -y msodbcsql17
+# optional: for bcp and sqlcmd
+ACCEPT_EULA=Y yum install -y mssql-tools
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc

--- a/scripts/Install-Postgres-Tools.ps1
+++ b/scripts/Install-Postgres-Tools.ps1
@@ -1,0 +1,10 @@
+try {
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    $ErrorActionPreference = "Stop";
+    c:\cfn\assets\postgres-11-winx64.exe --unattendedmodeui none --mode unattended --disable-components "server,pgAdmin,stackbuilder" --install_runtimes 0
+    Start-Sleep -s 60
+    & "C:\Program Files\PostgreSQL\11\installer\vcredist_x64.exe" /quiet /norestart
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/Install-Region.sh
+++ b/scripts/Install-Region.sh
@@ -1,0 +1,17 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Install-Region.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Configure-ODBC <path to Region xml>"
+  exit 1
+fi
+
+RegionXMLPath=$1
+export TERM="xterm"
+shift
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+mfds -g 5 $RegionXMLPath D

--- a/scripts/JoinTo-Domain-Linux.sh
+++ b/scripts/JoinTo-Domain-Linux.sh
@@ -1,0 +1,40 @@
+#! /bin/bash -e
+######################################################################
+# Script to join the instance to an Active Directory domain          #
+# Requires the following to already be installed:                    #
+# sssd realmd krb5-workstation samba-common-tools                    #
+######################################################################
+
+#Log output
+exec > >(tee /var/log/JoinTo-Domain-Linux.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 3 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "JoinTo-Domain-Linux.sh <Join_account> <Domain> <Password>"
+  exit 1
+fi
+
+Join_account=$1
+Domain=$2
+Password=$3
+
+# Join the domain
+echo $Password | realm join -v -U $Join_account $Domain --install=/
+
+# Allow domain users to logon via passwords
+sed -i '/PasswordAuthentication/s/no.*/yes/' /etc/ssh/sshd_config
+systemctl restart sshd.service
+
+realm permit Admin@$Domain
+
+#Give domain admins sudo privledges
+echo "%AWS\ Delegated\ Administrators@$Domain ALL=(ALL:ALL) ALL" | EDITOR='tee -a' visudo
+
+if [ $? -eq 0 ]; then
+    echo "JoinTo-Domain-Linux has passed" >> /var/log/cfn-init.log
+    exit 0
+else
+    echo "JoinTo-Domain-Linux has FAILED" >> /var/log/cfn-init.log
+    exit 1
+fi

--- a/scripts/MFDS-Listen-all.ps1
+++ b/scripts/MFDS-Listen-all.ps1
@@ -1,0 +1,10 @@
+try {
+    Write-Host "Configuring Directory Server"
+    $cmd = "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin\mfds.exe"
+    Start-Process -FilePath $cmd -ArgumentList "--listen-all" -Wait
+    Restart-Service -Name "MF_CCITCP2"
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}
+

--- a/scripts/Mount-Networkshare.sh
+++ b/scripts/Mount-Networkshare.sh
@@ -1,0 +1,9 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Mount-Networkshare.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+yum install nfs-utils rpcbind -y
+echo 'FSSERVER1:/FSdata /DATA nfs rw 0 0' >> /etc/fstab
+mkdir /DATA
+mount -a

--- a/scripts/NetworkShare-Setup.sh
+++ b/scripts/NetworkShare-Setup.sh
@@ -1,0 +1,15 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/NetworkShare-Setup.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+mkdir /FSdata/
+chmod -R 0777 /FSdata/
+
+systemctl enable nfs-server
+systemctl enable rpcbind
+systemctl start rpcbind
+systemctl start nfs-server
+echo '/FSdata *(rw,sync)' >> /etc/exports
+exportfs -r
+systemctl restart nfs-server

--- a/scripts/Prep-BankDemoDatabase.ps1
+++ b/scripts/Prep-BankDemoDatabase.ps1
@@ -50,6 +50,25 @@ try {
              CREATE User [MFDSServiceAccount] `
                FOR LOGIN [$DomainNetBIOSName\MFDSServiceAccount]"
 
+    # Create the Linux MFDBUser SQL Login
+    & "c:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd" `
+        -S ESDatabase `
+        -U $DBMasterUsername `
+        -P $DBMasterUserPassword `
+        -Q "CREATE Login [MFDBUser] `
+                WITH `
+                    PASSWORD='$DBMasterUserPassword', `
+                    default_database=BANKDEMO, `
+                    default_language=[us_english]"
+
+    # Create the MFDSServiceAccount User in BankDemo
+    & "c:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd" `
+        -S ESDatabase `
+        -U $DBMasterUsername `
+        -P $DBMasterUserPassword `
+        -Q "USE BANKDEMO; `
+             CREATE User [MFDBUser] `
+               FOR LOGIN [MFDBUser]"
     # Grant permissions
     & "c:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd" `
         -S ESDatabase `
@@ -57,8 +76,7 @@ try {
         -P $DBMasterUserPassword `
         -Q "USE BANKDEMO; `
              GRANT CONTROL `
-               TO [MFDSServiceAccount]"
-
+               TO [MFDSServiceAccount], [MFDBUser]"
 } catch {
      $_ | Write-AWSQuickStartException
 }

--- a/scripts/Prep-PACDemoDatabase.ps1
+++ b/scripts/Prep-PACDemoDatabase.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$DBMasterUsername,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DBMasterUserPassword
+)
+
+try {
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    $Env:PGPASSWORD = $DBMasterUserPassword
+    $Env:path += ";C:\Program Files\PostgreSQL\11\bin"
+    psql -h ESPACDatabase -U $DBMasterUsername -d postgres -c "CREATE DATABASE VSAM;"
+    psql -h ESPACDatabase -U $DBMasterUsername -d postgres -c "CREATE ROLE ESUser WITH login password '$DBMasterUserPassword';"
+    psql -h ESPACDatabase -U $DBMasterUsername -d postgres -c "ALTER USER esuser WITH CREATEDB CREATEROLE;"
+    psql -h ESPACDatabase -U $DBMasterUsername -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE VSAM TO ESUser;"
+} catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/RenameHost.sh
+++ b/scripts/RenameHost.sh
@@ -1,0 +1,16 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/RenameHost.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 2 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "RenameHost <Domain> <hostname>"
+  exit 1
+fi
+Domain=$1
+hostname=$2
+
+hostnamectl set-hostname $hostname.$Domain
+systemctl restart sssd.service

--- a/scripts/Schedule-AD-AddDNSServerResourceRecordCName.ps1
+++ b/scripts/Schedule-AD-AddDNSServerResourceRecordCName.ps1
@@ -36,10 +36,10 @@ try {
         throw "No DNS Servers found for domain $DomainDnsName"
     }
     $dnsServerIpAddress = $dnsServerAddresses[0].IPAddressToString;
-
+    $TName = "Add-DnsServerResourceRecordCName" + $CName
     # Schedule the Add-DNS call to run as <domain>\<domainuser> 10s from now and then delete the task 60s later
     c:\cfn\scripts\Schedule-AD-PowershellTask.ps1 `
-        -TaskName Add-DnsServerResourceRecordCName `
+        -TaskName "$TName" `
         -TaskArguments (
             "-Command Add-DnsServerResourceRecordCName "+ 
             "-Name $CName "+

--- a/scripts/Setup-Fileshare.sh
+++ b/scripts/Setup-Fileshare.sh
@@ -1,0 +1,25 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Setup-Fileshare.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Setup-Fileshare <FSVIEWUserPassword>"
+  exit 1
+fi
+FSVIEWUserPassword=$1
+export TERM="xterm"
+shift
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+
+cp -r /home/ec2-user/BankDemo_FS/System/catalog/data/* /FSdata
+mkdir /FSdata/PRC
+cp -r /home/ec2-user/BankDemo_FS/System/catalog/PRC/* /FSdata/PRC
+mkdir /FSdata/CTLCARDS
+cp -r /home/ec2-user/BankDemo_FS/System/catalog/CTLCARDS/* /FSdata/CTLCARDS
+cp /tmp/fs.conf /FSdata
+chmod 777 /FSdata/*
+fs -pf /FSdata/pass.dat -u SYSAD -pw SYSAD
+fs -pf /FSdata/pass.dat -u FSVIEW -pw $FSVIEWUserPassword

--- a/scripts/Setup-XA-resource.sh
+++ b/scripts/Setup-XA-resource.sh
@@ -1,0 +1,15 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Setup-XA-resource.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -ne 1 ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Setup-XA-resource <DBMasterPassword>"
+  exit 1
+fi
+
+DBMasterPassword=$1
+
+sed -i 's/Password123\!/'$DBMasterPassword'/g' /home/ec2-user/BankDemo_SQL/Repo/BNKDMSQL.xml

--- a/scripts/Start-Fileshare.sh
+++ b/scripts/Start-Fileshare.sh
@@ -1,0 +1,8 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Start-Fileshare.log|logger -t user-data -s 2>/dev/console) 2>&1
+export TERM="xterm"
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+cd /FSdata
+nohup fs -cf /FSdata/fs.conf &>/dev/null &

--- a/scripts/Start-MFDS.sh
+++ b/scripts/Start-MFDS.sh
@@ -1,0 +1,23 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Start-MFDS.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+
+export TERM="xterm"
+export COBMODE=32
+
+nohup mfds &>/dev/null &
+sleep 10
+MFDS_COUNT=`COLUMNS=180 ps -eaf | grep -c mfds `
+#remove the entry for grep
+let MFDS_COUNT-=1
+echo "MFDS_COUNT = $MFDS_COUNT"
+if ( test $MFDS_COUNT -lt "1")then
+    echo "MFDS was not started"
+    exit 1
+else
+    echo "success"
+    exit 0
+fi

--- a/scripts/Start-Region.sh
+++ b/scripts/Start-Region.sh
@@ -1,0 +1,45 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/Start-Region.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+if [ "$#" -lt "2" ]
+then
+  echo "Not Enough Arguments supplied."
+  echo "Start-Region <Region name> <COBMODE>"
+  exit 1
+fi
+
+Region=$1
+Mode=$2
+Start_Type=${3:-w}
+Delay=${4:-0}
+while (( "$#" )); do
+    shift
+done
+
+if [ $Delay -gt "0" ]; then
+    sleep $Delay
+fi
+
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+
+export TERM="xterm"
+export COBMODE=$Mode
+if [ "$Start_Type" == "c" ]; then
+    casstart -r$Region -s:c
+else
+    casstart -r$Region
+fi
+sleep 10
+REGION_COUNT=`COLUMNS=180 ps -eaf | grep -c $Region `
+#remove the entry for grep
+let REGION_COUNT-=1
+echo "REGION_COUNT = $REGION_COUNT"
+if ( test $REGION_COUNT -lt "1")then
+    echo "$Region was not started"
+    exit 1
+else
+    echo "success"
+    exit 0
+fi

--- a/scripts/StartESRegion-cold.ps1
+++ b/scripts/StartESRegion-cold.ps1
@@ -1,19 +1,13 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)]
-    [string]$RegionName,
-    [Parameter(Mandatory=$false)]
-    [string]$Delay
+    [string]$RegionName
 )
 
 try {
     $ErrorActionPreference = "Stop"
      Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
-     if ($Delay){
-         Start-Sleep -s 90
-     }
-	& "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin\casstart.exe" `
-		"-r$RegionName"
+	& "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin\casstart.exe" -r"$RegionName" -s:c
 
 } catch {
       $_ | Write-AWSQuickStartException

--- a/scripts/configure-and-import-pac-region.ps1
+++ b/scripts/configure-and-import-pac-region.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Regionname
+)
+try {
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    $ErrorActionPreference = "Stop"
+    function ImportRegion {
+        param (
+            [Parameter(Mandatory=$true)][String]$RegionName
+        )
+        & "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin\mfds" /g 5 C:\BankDemo_PAC\Repo\$RegionName.xml D
+    }
+    ImportRegion -RegionName $Regionname
+
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/scripts/deploy.bat
+++ b/scripts/deploy.bat
@@ -1,0 +1,31 @@
+@echo off
+set local
+
+set MFDBFH_CONFIG=C:\BankDemo_PAC\System\MFDBFH.cfg
+dbfhdeploy create sql://ESPACDatabase/VSAM
+
+:: deploy catalog into the db
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\CATALOG.DAT sql://ESPACDatabase/VSAM/CATALOG.DAT
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLDSN.dat sql://ESPACDatabase/VSAM/SPLDSN.dat
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLJNO.dat sql://ESPACDatabase/VSAM/SPLJNO.dat?type=seq;reclen=80,80
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLJOB.dat sql://ESPACDatabase/VSAM/SPLJOB.dat
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLMSG.dat sql://ESPACDatabase/VSAM/SPLMSG.dat
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLOUT.dat sql://ESPACDatabase/VSAM/SPLOUT.dat
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\SPLSUB.dat sql://ESPACDatabase/VSAM/SPLSUB.dat
+
+:: deploy data files into the db
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\data\MFI01V.MFIDEMO.BNKACC.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKACC.DAT?folder=/DATA
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\data\MFI01V.MFIDEMO.BNKATYPE.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKATYPE.DAT?folder=/DATA
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\data\MFI01V.MFIDEMO.BNKCUST.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKCUST.DAT?folder=/DATA
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\data\MFI01V.MFIDEMO.BNKHELP.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKHELP.DAT?folder=/DATA
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\data\MFI01V.MFIDEMO.BNKTXN.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKTXN.DAT?folder=/DATA
+
+:: deploy prc files
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\prc\YBATTSO.prc sql://ESPACDatabase/VSAM/YBATTSO.PRC?folder=/PRC;type=lseq;reclen=80,80
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\prc\YBNKEXTV.prc sql://ESPACDatabase/VSAM/YBNKEXTV.PRC?folder=/PRC;type=lseq;reclen=80,80
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\prc\YBNKPRT1.prc sql://ESPACDatabase/VSAM/YBNKPRT1.PRC?folder=/PRC;type=lseq;reclen=80,80
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\prc\YBNKSRT1.prc sql://ESPACDatabase/VSAM/YBNKSRT1.PRC?folder=/PRC;type=lseq;reclen=80,80
+
+:: deploy CTL cards
+dbfhdeploy -quiet data add C:\BankDemo_PAC\System\catalog\ctlcards\KBNKSRT1.txt sql://ESPACDatabase/VSAM/KBNKSRT1.TXT?folder=/CTLCARDS;type=lseq;reclen=80,80
+exit 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,33 @@
+#! /bin/bash -e
+
+#Log output
+exec > >(tee /var/log/deploy.log|logger -t user-data -s 2>/dev/console) 2>&1
+export MFDBFH_CONFIG=/home/ec2-user/BankDemo_PAC/System/MFDBFH.cfg
+source /opt/microfocus/EnterpriseDeveloper/bin/cobsetenv
+dbfhdeploy create sql://ESPACDatabase/VSAM
+
+# deploy catalog into the db
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/CATALOG.DAT sql://ESPACDatabase/VSAM/CATALOG.DAT
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLDSN.dat sql://ESPACDatabase/VSAM/SPLDSN.dat
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLJNO.dat sql://ESPACDatabase/VSAM/SPLJNO.dat?type=seq\;reclen=80,80
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLJOB.dat sql://ESPACDatabase/VSAM/SPLJOB.dat
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLMSG.dat sql://ESPACDatabase/VSAM/SPLMSG.dat
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLOUT.dat sql://ESPACDatabase/VSAM/SPLOUT.dat
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/SPLSUB.dat sql://ESPACDatabase/VSAM/SPLSUB.dat
+
+# deploy data files into the db
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/data/MFI01V.MFIDEMO.BNKACC.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKACC.DAT?folder=/DATA
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/data/MFI01V.MFIDEMO.BNKATYPE.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKATYPE.DAT?folder=/DATA
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/data/MFI01V.MFIDEMO.BNKCUST.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKCUST.DAT?folder=/DATA
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/data/MFI01V.MFIDEMO.BNKHELP.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKHELP.DAT?folder=/DATA
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/data/MFI01V.MFIDEMO.BNKTXN.DAT sql://ESPACDatabase/VSAM/MFI01V.MFIDEMO.BNKTXN.DAT?folder=/DATA
+
+# deploy prc files
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/prc/YBATTSO.PRC sql://ESPACDatabase/VSAM/YBATTSO.PRC?folder=/PRC\;type=lseq\;reclen=80,80
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/prc/YBNKEXTV.PRC sql://ESPACDatabase/VSAM/YBNKEXTV.PRC?folder=/PRC\;type=lseq\;reclen=80,80
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/prc/YBNKPRT1.PRC sql://ESPACDatabase/VSAM/YBNKPRT1.PRC?folder=/PRC\;type=lseq\;reclen=80,80
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/prc/YBNKSRT1.PRC sql://ESPACDatabase/VSAM/YBNKSRT1.PRC?folder=/PRC\;type=lseq\;reclen=80,80
+
+# deploy CTL cards
+dbfhdeploy -quiet data add /home/ec2-user/BankDemo_PAC/System/catalog/ctlcards/KBNKSRT1.TXT sql://ESPACDatabase/VSAM/KBNKSRT1.TXT?folder=/CTLCARDS\;type=lseq\;reclen=80,80
+exit

--- a/templates/mf-db-aurora-template.yaml
+++ b/templates/mf-db-aurora-template.yaml
@@ -1,0 +1,222 @@
+# © Copyright 2018 Micro Focus or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  "This template deploys a Micro Focus Enterprise Server Database instance in
+  private subnets. **WARNING** This template creates EC2 instances and related
+  resources. You will be billed for the AWS resources used if you create a stack
+  from this template. Micro Focus Enterprise Server is licensed separately,
+  please review the terms and conditions here
+  (https://www.microfocus.com/about/legal/) for further details. (qs-1qeg3mkqr)"
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - VPCID
+          - PrivateSubnet1AID
+          - PrivateSubnet2AID
+      - Label:
+          default: Microsoft Active Directory Configuration
+        Parameters:
+          - DirectoryServiceID
+      - Label:
+          default: Enterprise Server Database Configuration
+        Parameters:
+          - DBInstanceClass
+          - DBMasterUsername
+          - DBMasterUserPassword
+          - ESClientAccessSGID
+          - NotificationARN
+          - ESResourceNamePrefix
+    ParameterLabels:
+      DBInstanceClass:
+        default: Database Instance Class
+      DBMasterUsername:
+        default: Database Master Username
+      DBMasterUserPassword:
+        default: Database Master User password
+      DirectoryServiceID:
+        default: Directory Service ID
+      ESClientAccessSGID:
+        default: ES Client Access Security Group ID
+      ESResourceNamePrefix:
+        default: Resource 'Name' Prefix
+      NotificationARN:
+        default: Notification ARN
+      PrivateSubnet1AID:
+        default: Private Subnet 1A ID
+      PrivateSubnet2AID:
+        default: Private Subnet 2A ID
+      VPCID:
+        default: VPC ID
+Parameters:
+  DBInstanceClass:
+    AllowedValues:
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r2.8xlarge
+    Default: db.r4.large
+    Type: String
+  DBMasterUsername:
+    Type: String
+    Default: DBAdmin
+  DBMasterUserPassword:
+    Type: String
+    NoEcho: true
+  DirectoryServiceID:
+    Type: String
+  ESClientAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+  ESResourceNamePrefix:
+    Type: String
+    Default: 'AWS::StackName'
+  NotificationARN:
+    Description: >-
+      An existing Amazon SNS topic where notifications about are sent, e.g.,
+      email notifications
+    Type: String
+    Default: ''
+  PrivateSubnet1AID:
+    Description: 'ID of private subnet A in Availability Zone 1 (e.g., subnet-a0246dcd)'
+    Type: 'AWS::EC2::Subnet::Id'
+  PrivateSubnet2AID:
+    Description: >-
+      ID of private subnet A in Availability Zone 2 (e.g.,
+      subnet-01a43dc1ca1fa7f9b)
+    Type: 'AWS::EC2::Subnet::Id'
+  VPCID:
+    Description: ID of your existing VPC for deployment
+    Type: 'AWS::EC2::VPC::Id'
+Rules:
+  SubnetsInVPC:
+    Assertions:
+      - Assert:
+          'Fn::EachMemberIn':
+            - 'Fn::ValueOfAll':
+                - 'AWS::EC2::Subnet::Id'
+                - VpcId
+            - 'Fn::RefAll': 'AWS::EC2::VPC::Id'
+        AssertDescription: All subnets must in the VPC
+Conditions:
+  NamePrefixIaUndefined: !Equals
+    - !Ref ESResourceNamePrefix
+    - ''
+  NamePrefixIsAWSStackname: !Equals
+    - !Ref ESResourceNamePrefix
+    - 'AWS::StackName'
+  HaveDirectoryService: !Not
+    - !Equals
+      - !Ref DirectoryServiceID
+      - ''
+  HaveNotificationARN: !Not
+    - !Equals
+      - !Ref NotificationARN
+      - ''
+Resources:
+  ESDatabaseSG:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Enterprise Server SQL Server Security Group
+      VpcId: !Ref VPCID
+      SecurityGroupIngress:
+        - Description: Allow client access
+          IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref ESClientAccessSGID
+  ESDatabaseADIAMRole:
+    Type: 'AWS::IAM::Role'
+    Condition: HaveDirectoryService
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - rds.amazonaws.com
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess'
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Database subnet group
+      SubnetIds:
+        - !Ref PrivateSubnet1AID
+        - !Ref PrivateSubnet2AID
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      Engine: aurora-postgresql
+      EngineVersion: "10.7"
+      MasterUsername: !Ref DBMasterUsername
+      MasterUserPassword: !Ref DBMasterUserPassword
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      StorageEncrypted: false
+      DatabaseName: mydb
+      DBClusterParameterGroupName: default.aurora-postgresql10
+      Port:  5432
+      VpcSecurityGroupIds:
+        - !Ref ESDatabaseSG
+      BackupRetentionPeriod: 30
+    DependsOn: DatabaseSubnetGroup
+
+  ESDatabase:
+    Type: 'AWS::RDS::DBInstance'
+    DeletionPolicy: Delete
+    Properties:
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      DBClusterIdentifier: !Ref AuroraCluster
+      AllowMajorVersionUpgrade: false
+      AutoMinorVersionUpgrade: true
+      Engine: aurora-postgresql
+      DBInstanceClass: !Ref DBInstanceClass
+      PubliclyAccessible: false
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - '${StackNamePrefix}SQLServer Database'
+            - StackNamePrefix: !If
+                - NamePrefixIaUndefined
+                - ''
+                - !If
+                  - NamePrefixIsAWSStackname
+                  - !Sub '${AWS::StackName}-'
+                  - !Sub '${ESResourceNamePrefix}-'
+  ESDatabaseEventSubscriptions:
+    Type: 'AWS::RDS::EventSubscription'
+    Condition: HaveNotificationARN
+    Properties:
+      Enabled: true
+      EventCategories:
+        - configuration change
+        - failure
+        - deletion
+      SnsTopicArn: !Ref NotificationARN
+      SourceIds:
+        - !Ref ESDatabase
+      SourceType: db-instance
+Outputs:
+  ESPACDatabaseEndpointAddress:
+    Description: The connection endpoint for the database
+    Value: !GetAtt ESDatabase.Endpoint.Address
+  ESDatabaseEndpointPort:
+    Description: The port number on which the database accepts connections
+    Value: !GetAtt ESDatabase.Endpoint.Port

--- a/templates/mf-es-bootstrap-template.yaml
+++ b/templates/mf-es-bootstrap-template.yaml
@@ -1,4 +1,3 @@
----
 AWSTemplateFormatVersion: 2010-09-09
 Description: '"This template deploys a single Micro Focus Enterprise Server instance
   as defined in the Micro Focus Enterprise Server Reference Architecture. **WARNING**
@@ -30,6 +29,12 @@ Metadata:
       - MFDSServiceAccountName
       - MFDSServiceAccountPassword
       - ESS3BucketName
+    - Label:
+        default: PAC Configuration
+      Parameters:
+        - RedisEndPoint
+        - PACDBMasterUsername
+        - PACDBMasterUserPassword
     - Label:
         default: Fileshare Configuration
       Parameters:
@@ -86,12 +91,18 @@ Metadata:
         default: Micro Focus Directory Server service domain account name
       MFDSServiceAccountPassword:
         default: Micro Focus Directory Server service account password
+      PACDBMasterUsername: 
+        default: Database Master username
+      PACDBMasterUserPassword:
+        default: Database Master password
       SubnetID:
         default: Subnet ID
       QSS3BucketName:
         default: Quick Start S3 bucket name
       QSS3KeyPrefix:
         default: Quick Start S3 key prefix
+      RedisEndPoint:
+        default: Redis endpoint address
 Parameters:
   AvailabilityZones:
     Description: The list of Availability Zones to use for the subnets in the VPC.
@@ -150,6 +161,10 @@ Parameters:
     Type: String
     Description: The connection endpoint for the database
     Default: ''
+  ESPACDatabaseEndpointAddress:
+    Type: String
+    Description: The connection endpoint for the PAC database
+    Default: ''
   ESDemoUserPassword:
     AllowedPattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,32}$
     Description: The password for the ESDemoUser. Must contain 8 to 32 characters,
@@ -182,6 +197,14 @@ Parameters:
     Description: Choose 'false' if you don't want to install the Enterprise Server
       Fileshare demo app. Requires selection of the 'Create-Remote-Fileshare-Server'
       Fileshare type.
+  InstallPACDemoApp:
+    AllowedValues:
+    - true
+    - false
+    Default: true
+    Description: Choose 'false' if you don't want to install the Enterprise Server
+      PAC demo app.
+    Type: String
   InstallSQLDemoApp:
     AllowedValues:
     - true
@@ -215,6 +238,29 @@ Parameters:
     MaxLength: '32'
     MinLength: '8'
     NoEcho: true
+  PACDBMasterUsername:
+    Description: >-
+      Specify an alphanumeric string that defines the login ID for the master
+      user. Master user name must start with a letter. Must contain 1 to 64
+      alphanumeric characters.
+    AllowedPattern: >-
+      ^[a-zA-Z][a-zA-Z0-9]{1,64}$
+    ConstraintDescription: >-
+      Must start with a letter. Must contain 1 to 64 alphanumeric characters.
+    Default: DBAdmin
+    Type: String
+  PACDBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
   SubnetID:
     Description: The ID of a private subnet in an Availability Zone (e.g., subnet-a0246dcd).
     Type: AWS::EC2::Subnet::Id
@@ -238,6 +284,10 @@ Parameters:
       your own use. This prefix can include numbers, lowercase letters, uppercase
       letters, hyphens (-), and forward slashes (/).
     Type: String
+  RedisEndPoint:
+    Type: String
+    Description: The connection endpoint for redis
+    Default: ''
 Rules:
   KeyPairsNotEmpty:
     Assertions:
@@ -256,9 +306,14 @@ Conditions:
     !Or
     - !Condition InstallingFSDemoApp
     - !Condition InstallingSQLDemoApp
+    - !Condition InstallingPACDemoApp
   InstallingFSDemoApp:
     !Equals
     - !Ref InstallFSDemoApp
+    - 'true'
+  InstallingPACDemoApp:
+    !Equals
+    - !Ref InstallPACDemoApp
     - 'true'
   InstallingSQLDemoApp:
     !Equals
@@ -278,7 +333,7 @@ Conditions:
       - !Ref MFDSServiceAccountName
       - MFDSServiceAccount
 Resources:
-  ESInstanceRole:
+  BTSTRPInstanceRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -340,14 +395,14 @@ Resources:
             - ds:Describe*
             Effect: Allow
             Resource: '*'
-        PolicyName: ESInstancePolicy
-  ESInstanceRoleProfile:
+        PolicyName: BTSTRPInstancePolicy
+  BTSTRPInstanceRoleProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles:
-      - !Ref ESInstanceRole
-  ESInstance:
+      - !Ref BTSTRPInstanceRole
+  BTSTRPInstance:
     Type: AWS::EC2::Instance
     CreationPolicy:
       ResourceSignal:
@@ -357,7 +412,7 @@ Resources:
       AWS::CloudFormation::Authentication:
         S3AccessCreds:
           type: S3
-          roleName: !Ref ESInstanceRole
+          roleName: !Ref BTSTRPInstanceRole
           buckets:
           - !Ref QSS3BucketName
           - !Ref ESS3BucketName
@@ -371,22 +426,26 @@ Resources:
             - 030-Setup-Database-Client-Environment
             - 000-NoOperation
           - !If
+            - InstallingPACDemoApp
+            - 040-Setup-PAC-Database-Environment
+            - 000-NoOperation
+          - !If
             - CreateMFDSServiceAccount
-            - 040-CreateMFDSServiceAccount
+            - 050-CreateMFDSServiceAccount
             - 000-NoOperation
           - !If
             - InstallingAtLeastOneDemoApp
-            - 050-CreateBankDemoDomainUser
+            - 060-CreateBankDemoDomainUser
             - 000-NoOperation
           - !If
             - InstallingFSDemoApp
-            - 060-InstallBankDemoFS
+            - 070-InstallBankDemoFS
             - 000-NoOperation
           - !If
             - InstallingSQLDemoApp
-            - 070-InstallBankDemoSQL
+            - 080-InstallBankDemoSQL
             - 000-NoOperation
-          - 080-Finalize
+          - 090-Finalize
         000-NoOperation:
           commands:
             a-no-operation:
@@ -433,8 +492,8 @@ Resources:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
-                path=Resources.ESInstance.Metadata.AWS::CloudFormation::Init
-                action=cfn-init.exe -v -c config -s ${AWS::StackId} --resource ESInstance --region ${AWS::Region}
+                path=Resources.BTSTRPInstance.Metadata.AWS::CloudFormation::Init
+                action=cfn-init.exe -v -c config -s ${AWS::StackId} --resource BTSTRPInstance --region ${AWS::Region}
             c:\cfn\scripts\AddTo-SystemPath.ps1:
               source:
                 !Sub
@@ -494,7 +553,7 @@ Resources:
               waitAfterCompletion: '0'
             c-init-quickstart-module:
               command: !Sub 'powershell.exe -Command New-AWSQuickStartResourceSignal
-                -Stack ${AWS::StackName} -Resource ESInstance -Region ${AWS::Region}'
+                -Stack ${AWS::StackName} -Resource BTSTRPInstance -Region ${AWS::Region}'
               waitAfterCompletion: '0'
         020-RenameAndJoinDomain:
           commands:
@@ -547,7 +606,59 @@ Resources:
               command: powershell.exe -File c:\cfn\scripts\AddTo-SystemPath.ps1 -PathToAdd
                 "c:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn"
               waitAfterCompletion: '0'
-        040-CreateMFDSServiceAccount:
+        040-Setup-PAC-Database-Environment:
+          files:
+            'c:\cfn\assets\postgres-11-winx64.exe':
+              source: https://get.enterprisedb.com/postgresql/postgresql-11.5-1-windows-x64.exe
+            'c:\cfn\scripts\Prep-PACDemoDatabase.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Prep-PACDemoDatabase.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Schedule-AD-AddDNSServerResourceRecordCName.ps1':
+              source:
+                !Sub
+                - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Schedule-AD-AddDNSServerResourceRecordCName.ps1
+                - QSS3Region:
+                    !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Install-Postgres-Tools.ps1':
+              source:
+                !Sub
+                - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Install-Postgres-Tools.ps1
+                - QSS3Region:
+                    !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          commands:
+            a-install-postgres-tools:
+              command: !Sub 'powershell.exe -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1 
+              -TaskName Install-Postgres-Tools -TaskArguments "-File c:\cfn\scripts\Install-Postgres-Tools.ps1"
+              -DomainUserName "${DomainNetBIOSName}\Admin" -DomainUserPassword "${DomainAdminPassword}"'
+            b-schedule-add-database-cname-to-dns:
+              command: !Sub 'powershell.exe -File C:\cfn\scripts\Schedule-AD-AddDNSServerResourceRecordCName.ps1
+                -CName ESPACDatabase -HostNameAlias ${ESPACDatabaseEndpointAddress} -DomainDnsName
+                ${DomainDNSName} -DomainUserName Admin -DomainUserPassword ${DomainAdminPassword}'
+              waitAfterCompletion: '0'
+            c-configure-database:
+              cwd: 'C:\Program Files\PostgreSQL\11\bin'
+              command: !Sub 'powershell.exe -File c:\cfn\scripts\Prep-PACDemoDatabase.ps1 -DBMasterUsername ${PACDBMasterUsername}
+                -DBMasterUserPassword ${PACDBMasterUserPassword}'
+              waitAfterCompletion: '0'
+            d-schedule-add-redis-cname-to-dns:
+              command: !Sub 'powershell.exe -File C:\cfn\scripts\Schedule-AD-AddDNSServerResourceRecordCName.ps1
+                -CName ESRedis -HostNameAlias ${RedisEndPoint} -DomainDnsName
+                ${DomainDNSName} -DomainUserName Admin -DomainUserPassword ${DomainAdminPassword}'
+        050-CreateMFDSServiceAccount:
           commands:
             a-create-mfds-service-account:
               command: !Sub 'powershell.exe -File c:\cfn\scripts\New-ADUser.ps1 -NewUsername
@@ -556,7 +667,18 @@ Resources:
                 -DomainDnsName ${DomainDNSName} -DomainUserName Admin -DomainUserPassword
                 ${DomainAdminPassword}'
               waitAfterCompletion: '0'
-        050-CreateBankDemoDomainUser:
+        060-CreateBankDemoDomainUser:
+          files:
+            c:\cfn\scripts\Add-user-to-admin-group.ps1:
+              source:
+                !Sub
+                - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Add-user-to-admin-group.ps1
+                - QSS3Region:
+                    !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
           commands:
             a-create-esdemouser:
               command: !Sub 'powershell.exe -File c:\cfn\scripts\New-ADUser.ps1 -NewUsername
@@ -564,7 +686,12 @@ Resources:
                 "Enterprise Server Demos User" -DomainDnsName ${DomainDNSName} -DomainUserName
                 Admin -DomainUserPassword ${DomainAdminPassword}'
               waitAfterCompletion: '0'
-        060-InstallBankDemoFS:
+            b-add-esdemouser-to-admins:
+              command: !Sub 'powershell.exe -File c:\cfn\scripts\Add-user-to-admin-group.ps1 -Username
+                ESDemoUser -DomainDnsName ${DomainDNSName} -DomainUserName
+                Admin -DomainUserPassword ${DomainAdminPassword}'
+              waitAfterCompletion: '0'
+        070-InstallBankDemoFS:
           files:
             c:\cfn\scripts\Create-Mapped-Drive-GPO.ps1:
               source:
@@ -584,7 +711,7 @@ Resources:
                 ${FileshareDataFolderUNC} -DomainDnsName ${DomainDNSName}" -DomainUserName
                 "${DomainNetBIOSName}\Admin" -DomainUserPassword "${DomainAdminPassword}"'
               waitAfterCompletion: '0'
-        070-InstallBankDemoSQL:
+        080-InstallBankDemoSQL:
           files:
             C:\BankDemo_SQL\System\BankDemoCreateAll.SQL:
               source:
@@ -612,7 +739,7 @@ Resources:
                 -DomainNetBIOSName ${DomainNetBIOSName} -DBMasterUsername ${DBMasterUsername}
                 -DBMasterUserPassword ${DBMasterUserPassword}'
               waitAfterCompletion: '0'
-        080-Finalize:
+        090-Finalize:
           commands:
             a-finalize-init:
               command: powershell.exe -Command Write-AWSQuickStartStatus
@@ -629,7 +756,7 @@ Resources:
       SecurityGroupIds:
       - !Ref DomainMemberSGID
       - !Ref ESClientAccessSGID
-      IamInstanceProfile: !Ref ESInstanceRoleProfile
+      IamInstanceProfile: !Ref BTSTRPInstanceRoleProfile
       InstanceInitiatedShutdownBehavior: terminate
       KeyName: !Ref KeyPairName
       InstanceType: m5.large
@@ -654,11 +781,10 @@ Resources:
               start /wait C:\AmazonSSMAgentSetup.exe /install /quiet
 
               rem Run  cfn-init helper to process AWS::CloudFormation::Init directives
-              cfn-init.exe -v -c config -s ${AWS::StackName} --resource ESInstance --region ${AWS::Region}
+              cfn-init.exe -v -c config -s ${AWS::StackName} --resource BTSTRPInstance --region ${AWS::Region}
             </script>
           - QSS3Region:
               !If
               - GovCloudCondition
               - s3-us-gov-west-1
               - s3
-...

--- a/templates/mf-es-master-template.yaml
+++ b/templates/mf-es-master-template.yaml
@@ -52,14 +52,20 @@ Metadata:
           - RDGWInstanceType
           - RDGWCIDR
       - Label:
+          default: Linux Bastion Configuration
+        Parameters:
+          - NumberOfBastionHosts
+          - BastionInstanceType
+          - BastionCIDR
+      - Label:
           default: Enterprise Server Configuration
         Parameters:
+          - OS
           - ESInstanceType
           - NumberOfESInstance
           - KeyPairName
           - RegionsPerInstance
           - AdditionalESStorageinGiB
-          - ESCCITCPListenerPort
           - ESCWLogGroupRetentionInDays
           - MFDSServiceAccountName
           - MFDSServiceAccountPassword
@@ -68,13 +74,20 @@ Metadata:
           - ESS3BucketName
           - ESResourceNamePrefix
       - Label:
-          default: Fileshare Configuration
+          default: PAC Configuration
+        Parameters:
+          - InstallPACDemoApp
+          - PACDBInstanceClass
+          - PACDBMasterUsername
+          - PACDBMasterUserPassword
+          - PACDBMasterUserPasswordConfirm
+      - Label:
+          default: Enterprise Server Fileshare Configuration
         Parameters:
           - FileshareType
           - InstallFSDemoApp
           - FSInstanceType
           - FSStorageInGiB
-          - FSCCITCPListenerPort
           - FSVIEWUserPassword
           - FSVIEWUserPasswordConfirm
       - Label:
@@ -97,8 +110,6 @@ Metadata:
           - ESDemoUserPassword
           - ESDemoUserPasswordConfirm
           - DemoAppsIngressCIDR
-          - FSDemoApp3270Port
-          - SQLDemoApp3270Port
       - Label:
           default: AWS Quick Start Configuration
         Parameters:
@@ -109,6 +120,10 @@ Metadata:
         default: Additional Enterprise Server instance storage
       AvailabilityZones:
         default: Availability Zones
+      BastionCIDR:
+        default: Allowed Bastion External Access CIDR
+      BastionInstanceType:
+        default: Bastion Instance Type
       DatabaseType:
         default: Database type
       DBBackupRetentionPeriod:
@@ -141,14 +156,14 @@ Metadata:
         default: Domain NetBIOS name
       DSMicrosoftADEdition:
         default: AWS Managed Microsoft AD Edition
-      ESCCITCPListenerPort:
-        default: Enterprise Server CCITCP listener port
       ESCWLogGroupRetentionInDays:
         default: Amazon CloudWatch log retention
       ESDemoUserPassword:
         default: Enterprise Server Demo User password
       ESDemoUserPasswordConfirm:
         default: Re-enter the Enterprise Server Demo User password
+      OS:
+        default: Enterprise Server instance(s) OS type
       ESInstanceType:
         default: Enterprise Server instance type
       ESLicenseFilename:
@@ -161,16 +176,14 @@ Metadata:
         default: Fileshare type
       FSInstanceType:
         default: Enterprise Server Fileshare instance type
-      FSCCITCPListenerPort:
-        default: Enterprise Server Fileshare CCITCP listener port
       FSStorageInGiB:
         default: Fileshare allocated storage size
-      FSDemoApp3270Port:
-        default: Fileshare Bank Demo TN3270 Port
       FSVIEWUserPassword:
         default: FSVIEW user password
       FSVIEWUserPasswordConfirm:
         default: Re-enter the FSVIEW user password
+      InstallPACDemoApp:
+        default: Install PAC Demo App
       InstallFSDemoApp:
         default: Install Fileshare Demo App
       InstallSQLDemoApp:
@@ -185,12 +198,22 @@ Metadata:
         default: Micro Focus Directory Server service account password
       MFDSServiceAccountPasswordConfirm:
         default: Re-enter the Micro Focus Directory Server service account password
+      NumberOfBastionHosts:
+        default: Number of Bastion hosts
       NumberOfESInstance:
         default: Number of Enterprise Server instances
       NumberOfRDGWHosts:
         default: Number of RD Gateway hosts
       OperatorEmail:
         default: Operator email address
+      PACDBInstanceClass:
+        default: Database instance class
+      PACDBMasterUsername: 
+        default: PAC database Master username
+      PACDBMasterUserPassword:
+        default: PAC database Master password
+      PACDBMasterUserPasswordConfirm:
+        default: Re-enter the PAC database Master password
       PrivateSubnet1ACIDR:
         default: Private subnet 1A CIDR
       PrivateSubnet2ACIDR:
@@ -209,8 +232,6 @@ Metadata:
         default: RD Gateway instance type
       RegionsPerInstance:
         default: Number of Enterprise Server regions per instance
-      SQLDemoApp3270Port:
-        default: SQLServer Bank Demo TN3270 Port
       VPCCIDR:
         default: VPC CIDR
 Parameters:
@@ -228,18 +249,48 @@ Parameters:
       Quick Start uses two Availability Zones from your list and preserves the
       logical order you specify.
     Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  BastionCIDR:
+    AllowedPattern: >-
+      ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x.
+    Description: >-
+      The allowed CIDR block for external access to the Bastion host. The CIDR block must be in the form x.x.x.x/x.
+    Type: String
+  BastionInstanceType:
+    AllowedValues:
+      - t2.nano
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+    Default: t3.micro
+    Description: The Amazon EC2 instance type for the Bastion instances.
+    Type: String
   DatabaseType:
     AllowedValues:
       - None
       - Create-RDS-Remote-Database
-    Default: Create-RDS-Remote-Database
+    Default: None
     Description: >-
       If you choose 'None', the remaining Database Configuration parameters are
       ignored.
     Type: String
   DBBackupRetentionPeriod:
     Description: >-
-      The number of days that Amazon RDS should retain automatic backups
+      Select the number of days that Amazon RDS should retain automatic backups
       of the DB instance. A backup retention period of zero days will disable
       automated backups for the DB Instance.
     Default: 30
@@ -275,8 +326,8 @@ Parameters:
       printable ASCII character except "/", """, or "@".
     Description: >-
       The password for the DB master user. Must be at least eight characters
-      long, as in "mypassword". Can be any printable ASCII character except
-      "/", """, or "@".
+      long, as in "mypassword". Can be any printable ASCII character 
+      except "/", """, or "@".
     Type: String
     NoEcho: true
   DBMasterUserPasswordConfirm:
@@ -293,12 +344,12 @@ Parameters:
     NoEcho: true
   DBPreferredBackupWindow:
     Description: >-
-      Must be in the format hh24:mi-hh24:mi, in UTC. Must be at least 30
+      (optional) Must be in the format hh24:mi-hh24:mi, in UTC. Must be at least 30
       minutes, and must not conflict with the preferred maintenance window.
     Type: String
   DBPreferredMaintenanceWindow:
     Description: >-
-      Must be in the format ddd:hh24:mi-ddd:hh24:mi, in UTC. Must be at least 30
+      (optional) Must be in the format ddd:hh24:mi-ddd:hh24:mi, in UTC. Must be at least 30
       minutes.
     Type: String
   DBStorageInGiB:
@@ -363,21 +414,14 @@ Parameters:
   DSMicrosoftADEdition:
     Type: String
     Description: >-
-      Standard Edition includes 1GB of storage for objects. Enterprise Edition
-      includes 17GB. The total number of objects supported depends on the types
+      Standard Edition includes 1 GB of storage for objects. Enterprise Edition
+      includes 17 GB. The total number of objects supported depends on the types
       of objects, size of data stored in attributes, and your transaction rates.
       Scale-out as needed by adding domain controllers.
     AllowedValues:
       - Standard
       - Enterprise
     Default: Standard
-  ESCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535
-    Default: 86
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
   ESCWLogGroupRetentionInDays:
     Default: 7
     Description: The number of days that log events are kept in Amazon CloudWatch Logs.
@@ -410,6 +454,58 @@ Parameters:
     MinLength: '8'
     NoEcho: true
     Type: String
+  OS:
+    AllowedValues:
+      - Windows
+      - Red Hat Enterprise Linux
+    Description: The operating system type for the Enterprise Server instance(s).
+    Default: Windows
+    Type: String
+  PACDBInstanceClass:
+    AllowedValues:
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r2.8xlarge
+    Description: The type of Amazon RDS DB instance.
+    Default: db.r4.large
+    Type: String
+  PACDBMasterUsername:
+    Description: >-
+      Specify an alphanumeric string that defines the login ID for the master
+      user in the PAC database. Master user name must start with a letter. Must contain 1 to 64
+      alphanumeric characters.
+    AllowedPattern: >-
+      ^[a-zA-Z][a-zA-Z0-9]{1,64}$
+    ConstraintDescription: >-
+      Must start with a letter. Must contain 1 to 64 alphanumeric characters.
+    Default: DBAdmin
+    Type: String
+  PACDBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user in the PAC database. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
+  PACDBMasterUserPasswordConfirm:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      Confirm the password for the DB master user in the PAC database. Must be at least eight
+      characters long, as in "mypassword". Can be any printable ASCII character
+      except "/", """, or "@".
+    Type: String
+    NoEcho: true
   ESInstanceType:
     AllowedValues:
       - c5.large
@@ -447,20 +543,6 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
       start or end with a hyphen (-).
     Type: String
-  FSCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535
-    Default: 3000
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
-  FSDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5555'
-    Type: String
   FSInstanceType:
     AllowedValues:
       - c5.large
@@ -480,7 +562,7 @@ Parameters:
     AllowedValues:
       - None
       - Create-Remote-Fileshare-Server
-    Default: Create-Remote-Fileshare-Server
+    Default: None
     Description: >-
       If you choose 'None', the remaining Fileshare Configuration parameters
       are ignored.
@@ -513,22 +595,31 @@ Parameters:
     MinLength: '8'
     NoEcho: true
     Type: String
-  InstallFSDemoApp:
+  InstallPACDemoApp:
     Type: String
     AllowedValues:
       - true
       - false
     Default: true
     Description: >-
-      Choose 'false' if you don't want to install the Enterprise Server Fileshare demo
+      Choose 'false' if you don't want to install the Enterprise Server PAC demo
+      app.
+  InstallFSDemoApp:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
+    Description: >-
+      Choose 'true' if you want to install the Enterprise Server Fileshare demo
       app. Requires selection of the 'Create-Remote-Fileshare-Server' Fileshare type.
   InstallSQLDemoApp:
     AllowedValues:
       - true
       - false
-    Default: true
+    Default: false
     Description: >-
-      Choose 'false' if you don't want to install the Enterprise Server SQLServer demo
+      Choose 'true' if you want to install the Enterprise Server SQLServer demo
       app. Requires selection of the 'Create-RDS-Remote-Database' Database type.
     Type: String
   KeyPairName:
@@ -545,7 +636,7 @@ Parameters:
     AllowedValues:
       - I agree
       - '-'
-    ConstraintDescription: must answer 'I agree'
+    ConstraintDescription: Must answer 'I agree'.
   MFDSServiceAccountName:
     Type: String
     AllowedPattern: '[a-zA-Z0-9]*'
@@ -575,6 +666,18 @@ Parameters:
     MaxLength: '32'
     MinLength: '8'
     NoEcho: true
+    Type: String
+  NumberOfBastionHosts:
+    AllowedValues:
+      - None
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+    Default: '1'
+    Description: >-
+      If you choose 'None', the remaining Bastion configuration
+      parameters are ignored.
     Type: String
   NumberOfRDGWHosts:
     AllowedValues:
@@ -667,14 +770,9 @@ Parameters:
     Type: String
   RDGWInstanceType:
     AllowedValues:
+      - t2.small
+      - t2.medium
       - t2.large
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
       - m5.large
       - m5.xlarge
       - m5.2xlarge
@@ -691,13 +789,6 @@ Parameters:
     MaxValue: 10
     MinValue: 1
     Type: Number
-  SQLDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5349'
-    Type: String
   VPCCIDR:
     AllowedPattern: >-
       ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
@@ -706,25 +797,68 @@ Parameters:
     Description: The CIDR block for the VPC. The CIDR block must be in the form x.x.x.x/16-28.
     Type: String
 Rules:
+  DBMasterUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref DBMasterUserPassword
+          - !Ref DBMasterUserPasswordConfirm
+        AssertDescription: Database Master password values do not match.
+  DomainAdminPasswordsMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref DomainAdminPassword
+          - !Ref DomainAdminPasswordConfirm
+        AssertDescription: Domain Admin account password values do not match.
+  ESDemoUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref ESDemoUserPassword
+          - !Ref ESDemoUserPasswordConfirm
+        AssertDescription: Enterprise Server Demo user password values do not match.
+  FSVIEWUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref FSVIEWUserPassword
+          - !Ref FSVIEWUserPasswordConfirm
+        AssertDescription: FSVIEW user password values do not match.
+  MFDSServiceAccountPasswordsMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref MFDSServiceAccountPassword
+          - !Ref MFDSServiceAccountPasswordConfirm
+        AssertDescription: The Micro Focus Directory Server, Service Account password values do not match.
+  PACDBMasterUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref PACDBMasterUserPassword
+          - !Ref PACDBMasterUserPasswordConfirm
+        AssertDescription: The PAC database Master password values do not match.
   DSSupportedRegionRule:
     Assertions:
       - Assert: !Contains
-          - - ap-northeast-1  # Asia Pacific (Tokyo)
-            - ap-northeast-2  # Asia Pacific (Seoul)
-            - ap-south-1      # Asia Pacific (Mumbai)
-            - ap-southeast-1  # Asia Pacific (Singapore)
-            - ap-southeast-2  # Asia Pacific (Sydney)
-            - ca-central-1    # Canada (Central)
-            - eu-central-1    # EU (Frankfurt)
-#            - eu-north-1      # EU (Stockholm)             --> DirSrv not supported 2019-01-01
-            - eu-west-1       # EU (Ireland)
-            - eu-west-2       # EU (London)
-#            - eu-west-3       # EU (Paris)                 --> DirSrv not supported 2019-01-01
-            - sa-east-1       # South America (São Paulo)
-            - us-east-1       # US East (N. Virginia)
-            - us-east-2       # US East (Ohio)
-            - us-west-1       # US West (N. California)
-            - us-west-2       # US West (Oregon)
+          - - us-east-2          # US East (Ohio)
+            - us-east-1          # US East (N. Virginia)
+            - us-west-1          # US West (N. California)
+            - us-west-2          # US West (Oregon)
+            - ap-east-1          # Asia Pacific (Hong Kong)
+            - ap-south-1         # Asia Pacific (Mumbai)
+            # - ap-northeast-3     # Asia Pacific (Osaka-Local) --> Osaka-Local not supported, DirSrv not supported 2020-Feb-07
+            - ap-northeast-2     # Asia Pacific (Seoul)
+            - ap-southeast-1     # Asia Pacific (Singapore)
+            - ap-southeast-2     # Asia Pacific (Sydney)
+            - ap-northeast-1     # Asia Pacific (Tokyo)
+            - ca-central-1       # Canada (Central)
+            - cn-north-1         # China (Beijing)
+            - cn-northwest-1     # China (Ningxia)
+            - eu-central-1       # Europe (Frankfurt)
+            - eu-west-1          # Europe (Ireland)
+            - eu-west-2          # Europe (London)
+            - eu-west-3          # Europe (Paris)
+            - eu-north-1         # Europe (Stockholm)
+            # - me-south-1         # Middle East (Bahrain) --> DirSrv not supported 2020-Feb-07
+            - sa-east-1          # South America (Sao Paulo)
+            - us-gov-east-1      # AWS GovCloud (US-East)
+            - us-gov-west-1      # AWS GovCloud (US-West)
           - !Ref AWS::Region
         AssertDescription: This Quick Start utilizes AWS Directory Service which is not available in the chosen region.
           Please refer to https://docs.aws.amazon.com/general/latest/gr/rande.html#ds_region for a list
@@ -735,27 +869,63 @@ Rules:
       - Create-RDS-Remote-Database
     Assertions:
       - Assert: !Contains
-          - - ap-northeast-1  # Asia Pacific (Tokyo)
-            - ap-northeast-2  # Asia Pacific (Seoul)
-#            - ap-south-1      # Asia Pacific (Mumbai)      --> RDS-WinAuth not supported 2019-01-01
-            - ap-southeast-1  # Asia Pacific (Singapore)
-            - ap-southeast-2  # Asia Pacific (Sydney)
-            - ca-central-1    # Canada (Central)
-            - eu-central-1    # EU (Frankfurt)
-            - eu-north-1      # EU (Stockholm)
-            - eu-west-1       # EU (Ireland)
-            - eu-west-2       # EU (London)
-            - eu-west-3       # EU (Paris)
-#            - sa-east-1       # South America (São Paulo)  --> RDS-WinAuth not supported 2019-01-01
-            - us-east-1       # US East (N. Virginia)
-            - us-east-2       # US East (Ohio)
-#            - us-west-1       # US West (N. California)    --> RDS-WinAuth not supported 2019-01-01
-            - us-west-2       # US West (Oregon)
+          - - us-east-2          # US East (Ohio)
+            - us-east-1          # US East (N. Virginia)
+            # - us-west-1          # US West (N. California) --> RDS-WinAuth not supported 2020-Feb-07
+            - us-west-2          # US West (Oregon)
+            - ap-east-1          # Asia Pacific (Hong Kong)
+            # - ap-south-1         # Asia Pacific (Mumbai) --> RDS-WinAuth not supported 2020-Feb-07
+            - ap-northeast-3     # Asia Pacific (Osaka-Local)
+            - ap-northeast-2     # Asia Pacific (Seoul)
+            - ap-southeast-1     # Asia Pacific (Singapore)
+            - ap-southeast-2     # Asia Pacific (Sydney)
+            - ap-northeast-1     # Asia Pacific (Tokyo)
+            - ca-central-1       # Canada (Central)
+            - cn-north-1         # China (Beijing)
+            - cn-northwest-1     # China (Ningxia)
+            - eu-central-1       # Europe (Frankfurt)
+            - eu-west-1          # Europe (Ireland)
+            - eu-west-2          # Europe (London)
+            - eu-west-3          # Europe (Paris)
+            - eu-north-1         # Europe (Stockholm)
+            - me-south-1         # Middle East (Bahrain)
+            # - sa-east-1          # South America (Sao Paulo) --> RDS-WinAuth not supported 2020-Feb-07
+            # - us-gov-east-1      # AWS GovCloud (US-East) --> RDS-WinAuth not supported 2020-Feb-07
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> RDS-WinAuth not supported 2020-Feb-07
           - !Ref AWS::Region
         AssertDescription: This Quick Start utilizes Amazon Relational Database Service (Amazon RDS) Windows
           Authentication which is not available in the chosen region. Please refer to
           https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_SQLServerWinAuth.html
           for more details and launch the stack in one of the supported regions.
+  ESSupportedRegionRule:
+    Assertions:
+      - Assert: !Contains
+          - - us-east-2          # US East (Ohio)
+            - us-east-1          # US East (N. Virginia)
+            - us-west-1          # US West (N. California)
+            - us-west-2          # US West (Oregon)
+            #- ap-east-1          # Asia Pacific (Hong Kong) --> MFES not available
+            - ap-south-1         # Asia Pacific (Mumbai)
+            # - ap-northeast-3     # Asia Pacific (Osaka-Local) --> Osaka-Local not supported
+            - ap-northeast-2     # Asia Pacific (Seoul)
+            - ap-southeast-1     # Asia Pacific (Singapore)
+            - ap-southeast-2     # Asia Pacific (Sydney)
+            - ap-northeast-1     # Asia Pacific (Tokyo)
+            - ca-central-1       # Canada (Central)
+            # - cn-north-1         # China (Beijing) --> MFES not available
+            # - cn-northwest-1     # China (Ningxia) --> MFES not available
+            - eu-central-1       # Europe (Frankfurt)
+            - eu-west-1          # Europe (Ireland)
+            - eu-west-2          # Europe (London)
+            - eu-west-3          # Europe (Paris)
+            - eu-north-1         # Europe (Stockholm)
+            #- me-south-1         # Middle East (Bahrain) --> MFES not available
+            - sa-east-1          # South America (Sao Paulo)
+            # - us-gov-east-1      # AWS GovCloud (US-East) --> GovCloud not supported
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported 
+          - !Ref AWS::Region
+        AssertDescription: Micro Focus is not currently supporting this Quick Start in 
+          the chosen region. Please contact Micro Focus or launch into a different region.
   LicenseAgreementRule:
     Assertions:
       - Assert:
@@ -763,30 +933,6 @@ Rules:
             - - I agree
             - !Ref LicenseAgreement
         AssertDescription: User must agree to the terms of the license agreement.
-#  DomainAdminPasswordsMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref DomainAdminPassword
-#          - !Ref DomainAdminPasswordConfirm
-#        AssertDescription: Domain Admin account password values do not match.
-#  DBMasterUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref DBMasterUserPassword
-#          - !Ref DBMasterUserPasswordConfirm
-#        AssertDescription: Database Master password values do not match.
-#  ESDemoUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref ESDemoUserPassword
-#          - !Ref ESDemoUserPasswordConfirm
-#        AssertDescription: Enterprise Server Demo user password values do not match.
-#  FSVIEWUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref FSVIEWUserPassword
-#          - !Ref FSVIEWUserPasswordConfirm
-#        AssertDescription: FSVIEW user password values do not match.
   InstallFSDemoAppRule:
     RuleCondition: !Equals
       - !Ref InstallFSDemoApp
@@ -811,13 +957,11 @@ Rules:
         AssertDescription: >-
           Either choose a Database Type or select 'false' for Install SQLServer
           Demo App parameter.
-#  MFDSServiceAccountPasswordsMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref MFDSServiceAccountPassword
-#          - !Ref MFDSServiceAccountPasswordConfirm
-#        AssertDescription: The Micro Focus Directory Server, Service Account password values do not match.
 Conditions:
+  IncludeBastion: !Not
+    - !Equals
+      - !Ref NumberOfBastionHosts
+      - None
   IncludeRDGW: !Not
     - !Equals
       - !Ref NumberOfRDGWHosts
@@ -825,6 +969,10 @@ Conditions:
   InstallingAtLeastOneDemoApp: !Or
     - !Condition InstallingFSDemoApp
     - !Condition InstallingSQLDemoApp
+    - !Condition InstallingPACDemoApp
+  InstallingPACDemoApp: !Equals
+    - !Ref InstallPACDemoApp
+    - 'true'
   InstallingFSDemoApp: !Equals
     - !Ref InstallFSDemoApp
     - 'true'
@@ -941,6 +1089,51 @@ Resources:
           FromPort: 49152
           ToPort: 65535
           CidrIp: !Ref VPCCIDR
+        - Description: nfs communications
+          IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          CidrIp: !Ref VPCCIDR
+        - Description: nfs communications
+          IpProtocol: udp
+          FromPort: 2049
+          ToPort: 2049
+          CidrIp: !Ref VPCCIDR
+        - Description: RPC for nfs communications
+          IpProtocol: tcp
+          FromPort: 111
+          ToPort: 111
+          CidrIp: !Ref VPCCIDR
+        - Description: RPC for nfs communications
+          IpProtocol: udp
+          FromPort: 111
+          ToPort: 111
+          CidrIp: !Ref VPCCIDR
+        - Description: MFDS
+          IpProtocol: udp
+          FromPort: 86
+          ToPort: 86
+          CidrIp: !Ref VPCCIDR
+        - Description: MFDS
+          IpProtocol: tcp
+          FromPort: 86
+          ToPort: 86
+          CidrIp: !Ref VPCCIDR
+        - Description: ESCWA
+          IpProtocol: tcp
+          FromPort: 10004
+          ToPort: 10004
+          CidrIp: !Ref VPCCIDR
+        - Description: ElastiCache-Redis
+          IpProtocol: tcp
+          FromPort: 6379
+          ToPort: 6379
+          CidrIp: !Ref VPCCIDR
+        - Description: ESMAC Ports for the differnet BankDemos
+          IpProtocol: tcp
+          FromPort: 5558
+          ToPort: 5560
+          CidrIp: !Ref VPCCIDR
       VpcId: !GetAtt VPCStack.Outputs.VPCID
   RDGWStack:
     Type: 'AWS::CloudFormation::Stack'
@@ -986,11 +1179,62 @@ Resources:
         - !Ref NoRDGWWaitHandle
       Timeout: '1'
       Count: 0
+  BastionStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: IncludeBastion
+    DependsOn:
+      - VPCDHCPOptionsAssociationWaitCondition
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        BastionAMIOS: Amazon-Linux-HVM
+        BastionTenancy: default
+        BastionInstanceType: !Ref BastionInstanceType
+        EnableBanner: "false"
+        EnableTCPForwarding: "false"
+        EnableX11Forwarding: "false"
+        KeyPairName: !Ref KeyPairName
+        NumBastionHosts: !Ref NumberOfBastionHosts
+        PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
+        PublicSubnet2ID: !GetAtt VPCStack.Outputs.PublicSubnet2ID
+        QSS3BucketName: aws-quickstart
+        QSS3KeyPrefix: quickstart-linux-bastion/
+        RemoteAccessCIDR: !Ref BastionCIDR
+        VPCID: !GetAtt VPCStack.Outputs.VPCID
+  BastionCreateWaitHandle:
+    Condition: IncludeBastion
+    DependsOn: BastionStack
+    Type: 'AWS::CloudFormation::WaitConditionHandle'
+  NoBastionWaitHandle:
+    Type: 'AWS::CloudFormation::WaitConditionHandle'
+    DependsOn: VPCDHCPOptionsAssociationWaitCondition
+  BastionWaitCondition:
+    Type: 'AWS::CloudFormation::WaitCondition'
+    Properties:
+      Handle: !If
+        - IncludeBastion
+        - !Ref BastionCreateWaitHandle
+        - !Ref NoBastionWaitHandle
+      Timeout: '1'
+      Count: 0
+  DummySecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: >-
+        Dummy Security group. Gets passed through when no RDGW is selected.
+      VpcId: !GetAtt VPCStack.Outputs.VPCID
   EnterpriseServerWorkloadStack:
     Type: 'AWS::CloudFormation::Stack'
     DependsOn:
       - VPCDHCPOptionsAssociationWaitCondition
       - RDGWWaitCondition
+      - BastionWaitCondition
     Properties:
       TemplateURL: !Sub
         - >-
@@ -1021,30 +1265,33 @@ Resources:
         DomainDNSName: !Ref DomainDNSName
         DomainMemberSGID: !Ref DomainMemberSG
         DomainNetBIOSName: !Ref DomainNetBIOSName
-        ESCCITCPListenerPort: !Ref ESCCITCPListenerPort
         ESCWLogGroupRetentionInDays: !Ref ESCWLogGroupRetentionInDays
         ESDemoUserPassword: !Ref ESDemoUserPassword
         ESDemoUserPasswordConfirm: !Ref ESDemoUserPasswordConfirm
+        OS: !Ref OS
         ESInstanceType: !Ref ESInstanceType
         NumberOfESInstance: !Ref NumberOfESInstance
         ESLicenseFilename: !Ref ESLicenseFilename
         ESResourceNamePrefix: !Ref ESResourceNamePrefix
         ESS3BucketName: !Ref ESS3BucketName
         FileshareType: !Ref FileshareType
-        FSCCITCPListenerPort: !Ref FSCCITCPListenerPort
-        FSDemoApp3270Port: !Ref FSDemoApp3270Port
         FSInstanceType: !Ref FSInstanceType
         FSStorageInGiB: !Ref FSStorageInGiB
         FSVIEWUserPassword: !Ref FSVIEWUserPassword
         FSVIEWUserPasswordConfirm: !Ref FSVIEWUserPasswordConfirm
         InstallFSDemoApp: !Ref InstallFSDemoApp
         InstallSQLDemoApp: !Ref InstallSQLDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
         KeyPairName: !Ref KeyPairName
         LicenseAgreement: !Ref LicenseAgreement
         MFDSServiceAccountName: !Ref MFDSServiceAccountName
         MFDSServiceAccountPassword: !Ref MFDSServiceAccountPassword
         MFDSServiceAccountPasswordConfirm: !Ref MFDSServiceAccountPasswordConfirm
         OperatorEmail: !Ref OperatorEmail
+        PACDBInstanceClass: !Ref PACDBInstanceClass
+        PACDBMasterUsername: !Ref PACDBMasterUsername
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
+        PACDBMasterUserPasswordConfirm: !Ref PACDBMasterUserPasswordConfirm
         PrivateSubnet1AID: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
         PrivateSubnet2AID: !GetAtt VPCStack.Outputs.PrivateSubnet2AID
         PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
@@ -1054,9 +1301,12 @@ Resources:
         RDGWAccessSGID: !If
           - IncludeRDGW
           - !GetAtt RDGWStack.Outputs.RemoteDesktopGatewaySGID
-          - !Ref 'AWS::NoValue'
+          - !Ref DummySecurityGroup
+        BastionAccessSGID: !If
+          - IncludeBastion
+          - !GetAtt BastionStack.Outputs.BastionSecurityGroupID
+          - !Ref DummySecurityGroup
         RegionsPerInstance: !Ref RegionsPerInstance
-        SQLDemoApp3270Port: !Ref SQLDemoApp3270Port
         VPCID: !GetAtt VPCStack.Outputs.VPCID
 Outputs:
   DirectoryServiceID:
@@ -1066,15 +1316,7 @@ Outputs:
     Condition: InstallingAtLeastOneDemoApp
     Description: The DNS name of the Enterprise Server public load balancer
     Value: !GetAtt EnterpriseServerWorkloadStack.Outputs.ESDemoAppsPublicNetworkLoadBalancer
-  FSDemoApp3270Port:
-    Condition: InstallingFSDemoApp
-    Description: The Fileshare Bank Demo TN3270 port number
-    Value: !GetAtt EnterpriseServerWorkloadStack.Outputs.FSDemoApp3270Port
   RemoteDesktopGatewayIP:
     Condition: IncludeRDGW
     Description: Public IP Address for the Remote Desktop Gateway
     Value: !GetAtt RDGWStack.Outputs.EIP1
-  SQLDemoApp3270Port:
-    Condition: InstallingSQLDemoApp
-    Description: The SQLServer Bank Demo TN3270 port number
-    Value: !GetAtt EnterpriseServerWorkloadStack.Outputs.SQLDemoApp3270Port

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -1,0 +1,957 @@
+# © Copyright 2018 Micro Focus or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  "This template deploys a single Micro Focus Enterprise Server instance as
+  defined in the Micro Focus Enterprise Server Reference Architecture.
+  **WARNING** This template creates EC2 instances and related resources. You
+  will be billed for the AWS resources used if you create a stack from this
+  template. License: Apache 2.0 (Please do not remove) Sept,05,2018. Micro Focus
+  Enterprise Server is licensed separately, please review the terms and
+  conditions here (https://www.microfocus.com/about/legal/) for further details.
+  (qs-1qeg3mkuj)"
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Software License Agreement
+        Parameters:
+          - LicenseAgreement
+          - ESLicenseFilename
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - AvailabilityZones
+          - SubnetID
+      - Label:
+          default: Microsoft Active Directory Configuration
+        Parameters:
+          - DomainDNSName
+          - DomainMemberSGID
+          - DomainAdminPassword
+      - Label:
+          default: Enterprise Server Configuration
+        Parameters:
+          - ESInstanceType
+          - KeyPairName
+          - RegionsPerInstance
+          - AdditionalESStorageinGiB
+          - ESInstanceName
+          - ESClientAccessSGID
+          - ESS3BucketName
+          - EMailNotificationTopic
+          - ESCWLogGroup
+      - Label:
+          default: PAC Configuration
+        Parameters:
+          - PACDBMasterUserPassword
+      - Label:
+          default: Enterprise Server Demo Apps Configuration
+        Parameters:
+          - InstallFSDemoApp
+          - InstallSQLDemoApp
+          - InstallPACDemoApp
+      - Label:
+          default: Database Configuration
+        Parameters:
+          - DBMasterUserPassword
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      AdditionalESStorageinGiB:
+        default: Additional Enterprise Server instance storage
+      AvailabilityZones:
+        default: Availability Zones
+      DomainAdminPassword:
+        default: Domain Admin account password
+      DomainDNSName:
+        default: Domain DNS name
+      DomainMemberSGID:
+        default: Domain member Security Group ID
+      DBMasterUserPassword:
+        default: Database Master password
+      EMailNotificationTopic:
+        default: EMail Notification Topic
+      ESClientAccessSGID:
+        default: Enterprise Server Application (Client) Access Security Group ID
+      ESCWLogGroup:
+        default: Amazon CloudWatch Log Group
+      ESInstanceName:
+        default: Name of the Enterprise Server EC2 instance
+      ESInstanceType:
+        default: Enterprise Server instance type
+      ESLicenseFilename:
+        default: Enterprise Server license filename
+      ESS3BucketName:
+        default: Enterprise Server S3 bucket name
+      InstallFSDemoApp:
+        default: Install Fileshare Demo App
+      InstallSQLDemoApp:
+        default: Install SQLServer Demo App
+      InstallPACDemoApp:
+        default: Install PAC Demo App
+      KeyPairName:
+        default: Key pair name
+      LicenseAgreement:
+        default: License agreement
+      PACDBMasterUserPassword:
+        default: PAC database Master password
+      SubnetID:
+        default: Subnet ID
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+      RegionsPerInstance:
+        default: Number of Enterprise Server regions per instance
+Parameters:
+  AdditionalESStorageinGiB:
+    Type: Number
+    Description: >-
+      Additional EBS storage capacity in gibibytes (GiBs) added to each
+      Enterprise Server instance. Enter 0-16384 GiB.
+    MinValue: 0
+    MaxValue: 16384
+    Default: 100
+  AvailabilityZones:
+    Description: >-
+      The list of Availability Zones to use for the subnets in the VPC. The
+      Quick Start uses two Availability Zones from your list and preserves the
+      logical order you specify.
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  DomainAdminPassword:
+    AllowedPattern: >-
+      (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: >-
+      The password for the domain Admin account. Must be at least 8 characters
+      containing letters, numbers, and symbols.
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: true
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: >-
+      The fully qualified domain name (FQDN), e.g., example.com. Must be 2-255
+      characters.
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainMemberSGID:
+    Description: >-
+      The ID of the Domain Member Security Group (e.g., sg-7f16e910).
+    Type: 'AWS::EC2::SecurityGroup::Id'
+  DBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
+  EMailNotificationTopic:
+    Type: String
+    Default: ''
+  ESClientAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: >-
+      Security Group ID for application ingress into the Enterpriser Server
+      instance (e.g., sg-1234abcd).
+  ESCWLogGroup:
+    Type: String
+    Description: The logical ID of the Amazon CloudWatch Logs Log Group
+  ESInstanceName:
+    Type: String
+    Description: The name to assign to the Enterprise Server instance Windows Hostname
+  ESInstanceType:
+    AllowedValues:
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+    Description: The type of Enterprise Server instance.
+    Default: c5.large
+    Type: String
+  ESLicenseFilename:
+    Description: >-
+      Place the license file obtained from Micro Focus in the S3 bucket folder:
+      s3://<Enterprise Server S3 bucket name>/license/
+    Type: String
+  ESS3BucketName:
+    AllowedPattern: '^[a-z0-9][a-z0-9-.]*$'
+    Description: >-
+      The name of the existing S3 bucket used to store/retrieve objects specific
+      to this stack. A system integrator extending this Quick Start should use
+      this bucket to store or retrieve items needed. This string can include
+      numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
+      start or end with a hyphen (-).
+    Type: String
+  InstallFSDemoApp:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: >-
+      Choose 'false' if you don't want to install the Enterprise Server Fileshare demo
+      app. Requires selection of the 'Create-Remote-Fileshare-Server' Fileshare type.
+  InstallSQLDemoApp:
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: >-
+      Choose 'false' if you don't want to install the Enterprise Server SQLServer demo
+      app. Requires selection of the 'Create-RDS-Remote-Database' Database type.
+    Type: String
+  InstallPACDemoApp:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: >-
+      Choose 'false' if you don't want to install the Enterprise Server PAC demo
+      app.
+  KeyPairName:
+    Description: >-
+      The name of an existing EC2 key pair. All instances will launch with this key pair.
+    Type: 'AWS::EC2::KeyPair::KeyName'
+  LicenseAgreement:
+    Description: >-
+      I have read and agree to the license terms for Micro Focus Enterprise
+      Server
+      (https://www.microfocus.com/documentation/enterprise-developer/ed-latest/ES-WIN/GUID-0562B3C9-2271-4CE8-AF64-93DE4940077F.html).
+    Type: String
+    Default: '-'
+    AllowedValues:
+      - I agree
+      - '-'
+    ConstraintDescription: must answer 'I agree'.
+  PACDBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
+  SubnetID:
+    Description: 'The ID of a private subnet in an Availability Zone (e.g., subnet-a0246dcd).'
+    Type: 'AWS::EC2::Subnet::Id'
+  QSS3BucketName:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can
+      include numbers, lowercase letters, uppercase letters, and hyphens (-). It
+      cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: '^[0-9a-zA-Z-/]*$'
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase
+      letters, hyphens (-), and forward slash (/).
+    Default: quickstart-microfocus-amc-es/
+    Description: >-
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can
+      include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+  RegionsPerInstance:
+    ConstraintDescription: Must be between 1 and 10 regions per instance.
+    Description: >-
+      The number of regions per Enterprise Server instance. Must be between 1 and
+      10 regions per instance.
+    Default: 1
+    MaxValue: 10
+    MinValue: 1
+    Type: Number
+Rules:
+  KeyPairsNotEmpty:
+    Assertions:
+      - Assert: !Not
+          - 'Fn::EachMemberEquals':
+              - 'Fn::RefAll': 'AWS::EC2::KeyPair::KeyName'
+              - ''
+        AssertDescription: All key pair parameters must not be empty.
+  LicenseAgreementRule:
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+            - - I agree
+            - !Ref LicenseAgreement
+        AssertDescription: User must agree to the terms of the license agreement.
+Mappings:
+  AWSAMIRegionMap:
+    AMI:
+      MFES40AMI: ES_50_PU05_RH_V1
+    ap-northeast-1:
+      MFES40AMI: ami-05d1842beab710b38
+    ap-northeast-2:
+      MFES40AMI: ami-0cf8cb7aff561c1c6
+    ap-south-1:
+      MFES40AMI: ami-0c298dd9691aba765
+    ap-southeast-1:
+      MFES40AMI: ami-0359dbf0b49908990
+    ap-southeast-2:
+      MFES40AMI: ami-0a564bf05f121468d
+    ca-central-1:
+      MFES40AMI: ami-0af0bef96f2738cb8
+    eu-central-1:
+      MFES40AMI: ami-072da8340c7ac3c90
+    eu-north-1:
+      MFES40AMI: ami-078851e55a0205bd3
+    eu-west-1:
+      MFES40AMI: ami-04fc334c1c571095b
+    eu-west-2:
+      MFES40AMI: ami-0b00fe6f6d1f8cf8a
+    eu-west-3:
+      MFES40AMI: ami-09634aba2e3e9af51
+    sa-east-1:
+      MFES40AMI: ami-0dbc3f6e6eb8cc52c
+    us-east-1:
+      MFES40AMI: ami-0a7658bdbac09c2f5
+    us-east-2:
+      MFES40AMI: ami-0644d10d2c8e259d0
+    us-west-1:
+      MFES40AMI: ami-0eaaa90f16236c7b8
+    us-west-2:
+      MFES40AMI: ami-0a702c05587e75698
+Conditions:
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
+  HaveESlicenseFilename: !Not
+    - !Equals
+      - !Ref ESLicenseFilename
+      - ''
+  InstallingFSDemoApp: !Equals
+    - !Ref InstallFSDemoApp
+    - 'true'
+  InstallingSQLDemoApp: !Equals
+    - !Ref InstallSQLDemoApp
+    - 'true'
+  InstallingPACDemoApp: !Equals
+    - !Ref InstallPACDemoApp
+    - 'true'
+  HaveEMailNotificationTopic: !Not
+    - !Equals
+      - !Ref EMailNotificationTopic
+      - ''
+Resources:
+  ESInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:GetObject'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+            Version: 2012-10-17
+          PolicyName: aws-quick-start-s3-policy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:*'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}/*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+              - Action:
+                  - 'ds:Describe*'
+                Effect: Allow
+                Resource: '*'
+          PolicyName: ESInstancePolicy
+  ESInstanceRoleProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref ESInstanceRole
+  LambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  CalcPrimaryDataVolumeStorageSizeFunction:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        ZipFile: |
+          var response = require('cfn-response');
+          exports.handler = function(event, context) {
+            var props = event.ResourceProperties;
+            var result = (parseInt(props.RegionsPerInstance) * parseInt(props.RegionStorageOverheadInGiB)) + parseInt(props.AdditionalESStorageinGiB);
+            response.send(event, context, response.SUCCESS, {Value: result});
+          };
+      Runtime: nodejs12.x
+  ESPrimaryDataVolumeStorageSize:
+    Type: 'Custom::CalcPrimaryDataVolumeStorageSizeFunction'
+    Properties:
+      ServiceToken: !GetAtt CalcPrimaryDataVolumeStorageSizeFunction.Arn
+      RegionsPerInstance: !Ref RegionsPerInstance
+      RegionStorageOverheadInGiB: 50
+      AdditionalESStorageinGiB: !Ref AdditionalESStorageinGiB
+      Value: 0
+  ESPrimaryDataVolume:
+    Type: 'AWS::EC2::Volume'
+    Properties:
+      VolumeType: gp2
+      Size: !GetAtt ESPrimaryDataVolumeStorageSize.Value
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-${ESInstanceName} Data Volume'
+  ESInstance:
+    Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT20M
+    Metadata:
+      'AWS::CloudFormation::Authentication':
+        S3AccessCreds:
+          type: S3
+          roleName: !Ref ESInstanceRole
+          buckets:
+            - !Ref QSS3BucketName
+            - !Ref ESS3BucketName
+      'AWS::CloudFormation::Init':
+        configSets:
+          config:
+            - 000-NoOperation
+            - 010-JoinDomain
+            - !If
+              - HaveESlicenseFilename
+              - 020-ApplyESLicenseFile
+              - 000-NoOperation
+            - !If
+              - InstallingSQLDemoApp
+              - 030-ConfigureODBC
+              - 000-NoOperation
+            - !If
+              - InstallingPACDemoApp
+              - 040-Setup-PAC-Database-Envrionment
+              - 000-NoOperation
+            - !If
+              - InstallingFSDemoApp
+              - 050-InstallBankDemoFS
+              - 000-NoOperation
+            - !If
+              - InstallingSQLDemoApp
+              - 070-InstallBankDemoSQL
+              - 000-NoOperation
+            - !If
+              - InstallingPACDemoApp
+              - 060-InstallBankDemoPAC
+              - 000-NoOperation
+            - !If
+              - InstallingFSDemoApp
+              - 080-StartBNKDMFS
+              - 000-NoOperation
+            - !If
+              - InstallingSQLDemoApp
+              - 090-StartBNKDMSQL
+              - 000-NoOperation
+            - !If
+              - InstallingPACDemoApp
+              - 100-StartBNKDM
+              - 000-NoOperation
+        000-NoOperation:
+          commands:
+            a-no-operation:
+              command: echo "No-Operation" > nul
+              waitAfterCompletion: '0'
+        010-JoinDomain:
+          files:
+            '/tmp/JoinTo-Domain-Linux.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/JoinTo-Domain-Linux.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/RenameHost.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/RenameHost.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-JoinDomain:
+              command: !Sub
+                ./tmp/JoinTo-Domain-Linux.sh Admin ${DomainDNSName} '${DomainAdminPassword}'
+              waitAfterCompletion: '0'
+            b-RenameMachine:
+              command: !Sub
+                ./tmp/RenameHost.sh ${DomainDNSName} ${ESInstanceName}
+              waitAfterCompletion: '0'
+        020-ApplyESLicenseFile:
+          files:
+            '/tmp/Enterprise-Server.mflic':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/license/${ESLicenseFilename}
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Start-MFDS.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-MFDS.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-install-license:
+              command:
+                ./var/microfocuslicensing/bin/cesadmintool.sh -install /tmp/Enterprise-Server.mflic
+            b-start-mfds:
+              command:
+                ./tmp/Start-MFDS.sh
+        030-ConfigureODBC:
+          files:
+            '/tmp/Install-ODBC.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Install-ODBC.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Configure-ODBC.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Configure-ODBC.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-InstallDrivers:
+              command:
+                ./tmp/Install-ODBC.sh
+              waitAfterCompletion: '0'
+            b-AddDSNEntries:
+              command:
+                ./tmp/Configure-ODBC.sh ESDatabase
+              waitAfterCompletion: '0'
+        040-Setup-PAC-Database-Envrionment:
+          files:
+            '/tmp/Create-ps-DSN.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Create-ps-DSN.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-Create-Postgres-DSN:
+              command: !Sub
+                /tmp/Create-ps-DSN.sh ${PACDBMasterUserPassword}
+              waitAfterCompletion: '0'
+        050-InstallBankDemoFS:
+          files:
+            '/tmp/Mount-Networkshare.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Mount-Networkshare.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Install-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Install-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-ImportBNKDMFS:
+              command:
+                ./tmp/Install-Region.sh "/home/ec2-user/BankDemo_FS/Repo/BNKDMFS.xml"
+              waitAfterCompletion: '0'
+            b-MountNetworkShare:
+              command:
+                ./tmp/Mount-Networkshare.sh
+        060-InstallBankDemoPAC:
+          files:
+            '/tmp/Install-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Install-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/deploy.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/deploy.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Add-region-to-PAC.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Add-region-to-PAC.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-ImportBNKDM:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer1" ];then exit 0; else exit 1 ;fi
+              command:
+                ./tmp/Install-Region.sh "/home/ec2-user/BankDemo_PAC/Repo/BNKDM.xml"
+              waitAfterCompletion: '0'
+            b-ImportBNKDM2:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer2" ];then exit 0; else exit 1 ;fi
+              command:
+                ./tmp/Install-Region.sh "/home/ec2-user/BankDemo_PAC/Repo/BNKDM2.xml"
+            c-import-data-files:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer1" ];then exit 0; else exit 1 ;fi
+              command:
+                  ./tmp/deploy.sh
+              waitAfterCompletion: '0'
+            d-add-region-to-pac:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer1" ];then exit 0; else exit 1 ;fi
+              command: !Sub
+                ./tmp/Add-region-to-PAC.sh ${ESInstanceName} BNKDM
+              waitAfterCompletion: '0'
+            e-add-region-to-pac2:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer2" ];then exit 0; else exit 1 ;fi
+              command: !Sub
+                ./tmp/Add-region-to-PAC.sh ${ESInstanceName} BNKDM2
+              waitAfterCompletion: '0'
+        070-InstallBankDemoSQL:
+          files:
+            '/tmp/Install-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Install-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Setup-XA-resource.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Setup-XA-resource.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-ImportBNKDMFS:
+              command:
+                /tmp/Install-Region.sh "/home/ec2-user/BankDemo_SQL/Repo/BNKDMSQL.xml"
+              waitAfterCompletion: '0'
+            b-Setup-XA-Resource:
+              command: !Sub
+                /tmp/Setup-XA-resource.sh ${DBMasterUserPassword}
+              waitAfterCompletion: '0'
+        080-StartBNKDMFS:
+          files:
+            '/tmp/Start-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-StartBNKDMFS:
+              command:
+                ./tmp/Start-Region.sh BNKDMFS 32
+              waitAfterCompletion: '0'
+        090-StartBNKDMSQL:
+          files:
+            '/tmp/Start-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-StartBNKDMSQL:
+              command:
+                ./tmp/Start-Region.sh BNKDMSQL 64
+              waitAfterCompletion: '0'
+        100-StartBNKDM:
+          files:
+            '/tmp/Start-Region.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-Region.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-StartBNKDM:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer1" ];then exit 0; else exit 1 ;fi
+              command:
+                ./tmp/Start-Region.sh BNKDM 64 c
+              waitAfterCompletion: '0'
+            b-StartBNKDM2:
+              test: !Sub >-
+                if [ "${ESInstanceName}" == "ESServer2" ];then exit 0; else exit 1 ;fi
+              command:
+                ./tmp/Start-Region.sh BNKDM2 64 w 180
+              waitAfterCompletion: '0'
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
+      Volumes:
+        - VolumeId: !Ref ESPrimaryDataVolume
+          Device: xvdb
+      SubnetId: !Ref SubnetID
+      SecurityGroupIds:
+        - !Ref DomainMemberSGID
+        - !Ref ESClientAccessSGID
+      IamInstanceProfile: !Ref ESInstanceRoleProfile
+      KeyName: !Ref KeyPairName
+      InstanceType: !Ref ESInstanceType
+      ImageId: !FindInMap
+        - AWSAMIRegionMap
+        - !Ref 'AWS::Region'
+        - MFES40AMI
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-${ESInstanceName}'
+      UserData: !Base64
+        'Fn::Join':
+          - ''
+          - - |
+              #!/bin/bash -xe
+            - | 
+              exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+            - >
+              rpm -Uvh
+              https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+            - |
+              yum -y install python-pip
+            - >
+              /bin/easy_install --script-dir /opt/aws/bin 
+              https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+            - >
+              cp -f `pip show aws-cfn-bootstrap 2>/dev/null|grep -E "^Location"|awk
+              -F: '{print $2}'`/init/redhat/cfn-hup /etc/init.d/
+            - |
+              chmod 755 /etc/init.d/cfn-hup
+              chkconfig --add cfn-hup
+            - >-
+              /opt/aws/bin/cfn-init -v --stack 
+            - !Ref 'AWS::StackName' 
+            - ' --resource ESInstance
+              --configsets config 
+              --region '
+            - !Ref 'AWS::Region'
+            - |+
+            
+            - '/opt/aws/bin/cfn-signal -e $? --stack '
+            - !Ref 'AWS::StackName'
+            - ' --resource ESInstance --region '
+            - !Ref 'AWS::Region'
+            - |+
+  ESInstanceRecoveryAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: !Sub |
+        "${AWS::StackName} Stack instance auto-recovery alarm/trigger."
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed_System
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 5
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+        - !Sub 'arn:aws:automate:${AWS::Region}:ec2:recover'
+        - !If
+          - HaveEMailNotificationTopic
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref ESInstance
+Outputs:
+  ESInstanceID:
+    Description: The Enterprise Server EC2 Instance ID
+    Value: !Ref ESInstance
+  ESInstanceAZ:
+    Description: >-
+      The Availability Zone where the deployed Enterprise Server instance is
+      launched.
+    Value: !GetAtt ESInstance.AvailabilityZone
+  ESInstancePrivateDnsName:
+    Description: The private DNS name of the deployed Enterprise Server instance
+    Value: !GetAtt ESInstance.PrivateDnsName
+  ESInstancePrivateIp:
+    Description: The private IP address of the deployed Enterprise Server instance
+    Value: !GetAtt ESInstance.PrivateIp

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -48,7 +48,6 @@ Metadata:
           - KeyPairName
           - RegionsPerInstance
           - AdditionalESStorageinGiB
-          - ESCCITCPListenerPort
           - MFDSServiceAccountName
           - MFDSServiceAccountPassword
           - ESInstanceName
@@ -57,9 +56,9 @@ Metadata:
           - EMailNotificationTopic
           - ESCWLogGroup
       - Label:
-          default: Fileshare Configuration
+          default: PAC Configuration
         Parameters:
-          - FileshareDataFolderUNC
+          - PACDBMasterUserPassword
       - Label:
           default: Database Configuration
         Parameters:
@@ -69,8 +68,7 @@ Metadata:
         Parameters:
           - InstallFSDemoApp
           - InstallSQLDemoApp
-          - FSDemoApp3270Port
-          - SQLDemoApp3270Port
+          - InstallPACDemoApp
       - Label:
           default: AWS Quick Start Configuration
         Parameters:
@@ -91,8 +89,6 @@ Metadata:
         default: Domain member Security Group ID
       EMailNotificationTopic:
         default: EMail Notification Topic
-      ESCCITCPListenerPort:
-        default: Enterprise Server CCITCP listener port
       ESClientAccessSGID:
         default: Enterprise Server Application (Client) Access Security Group ID
       ESCWLogGroup:
@@ -107,14 +103,12 @@ Metadata:
         default: Enterprise Server license filename
       ESS3BucketName:
         default: Enterprise Server S3 bucket name
-      FileshareDataFolderUNC:
-        default: FileShare Data Folder UNC
-      FSDemoApp3270Port:
-        default: Fileshare Bank Demo TN3270 Port
       InstallFSDemoApp:
         default: Install Fileshare Demo App
       InstallSQLDemoApp:
         default: Install SQLServer Demo App
+      InstallPACDemoApp:
+        default: Install PAC Demo App
       KeyPairName:
         default: Key pair name
       LicenseAgreement:
@@ -123,6 +117,8 @@ Metadata:
         default: Micro Focus Directory Server service domain account name
       MFDSServiceAccountPassword:
         default: Micro Focus Directory Server service account password
+      PACDBMasterUserPassword:
+        default: Database Master password
       SubnetID:
         default: Subnet ID
       QSS3BucketName:
@@ -131,8 +127,6 @@ Metadata:
         default: Quick Start S3 key prefix
       RegionsPerInstance:
         default: Number of Enterprise Server regions per instance
-      SQLDemoApp3270Port:
-        default: SQLServer Bank Demo TN3270 Port
 Parameters:
   AdditionalESStorageinGiB:
     Type: Number
@@ -187,13 +181,6 @@ Parameters:
     Description: >-
       Security Group ID for application ingress into the Enterpriser Server
       instance (e.g., sg-1234abcd).
-  ESCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535.
-    Default: 86
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
   ESCWLogGroup:
     Type: String
     Description: The logical ID of the Amazon CloudWatch Logs Log Group
@@ -227,17 +214,6 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
       start or end with a hyphen (-).
     Type: String
-  FileshareDataFolderUNC:
-    Type: String
-    Description: The UNC of the Enterprise Server Fileshare data folder
-    Default: ''
-  FSDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5555'
-    Type: String
   InstallFSDemoApp:
     Type: String
     AllowedValues:
@@ -256,6 +232,15 @@ Parameters:
       Choose 'false' if you don't want to install the Enterprise Server SQLServer demo
       app. Requires selection of the 'Create-RDS-Remote-Database' Database type.
     Type: String
+  InstallPACDemoApp:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: >-
+      Choose 'false' if you don't want to install the Enterprise Server PAC demo
+      app.
   KeyPairName:
     Description: >-
       The name of an existing EC2 key pair. All instances will launch with this key pair.
@@ -291,6 +276,18 @@ Parameters:
     MaxLength: '32'
     MinLength: '8'
     NoEcho: true
+  PACDBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
   SubnetID:
     Description: 'The ID of a private subnet in an Availability Zone (e.g., subnet-a0246dcd).'
     Type: 'AWS::EC2::Subnet::Id'
@@ -325,13 +322,6 @@ Parameters:
     MaxValue: 10
     MinValue: 1
     Type: Number
-  SQLDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5349'
-    Type: String
 Rules:
   KeyPairsNotEmpty:
     Assertions:
@@ -350,39 +340,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_40PU4_V3
+      MFES40AMI: ES_50_PU05
     ap-northeast-1:
-      MFES40AMI: ami-0d8abeda47ca57871
+      MFES40AMI: ami-0dff3f5a16ecacfe5
     ap-northeast-2:
-      MFES40AMI: ami-05dccbfcdcf0adf6f
+      MFES40AMI: ami-0248d8806a80ec1be
     ap-south-1:
-      MFES40AMI: ami-09beff70828ed8de7
+      MFES40AMI: ami-07c28d590f4c42580
     ap-southeast-1:
-      MFES40AMI: ami-056340469fc88e360
+      MFES40AMI: ami-0a8d6fe92bdb3a94f
     ap-southeast-2:
-      MFES40AMI: ami-00f7e3a908d0e4499
+      MFES40AMI:  ami-05d45ddc80bfd6446
     ca-central-1:
-      MFES40AMI: ami-09b7e0eccba7305d5
+      MFES40AMI: ami-0f0adf2454aa54382
     eu-central-1:
-      MFES40AMI: ami-0748eb1177837591c
+      MFES40AMI: ami-00664de4c7c03a310
     eu-north-1:
-      MFES40AMI: ami-0dbf576f5ad8a6bbd
+      MFES40AMI: ami-09a1a20c436e7806e
     eu-west-1:
-      MFES40AMI: ami-0afd368a7655b6dfb
+      MFES40AMI: ami-03e0b7531700529c5
     eu-west-2:
-      MFES40AMI: ami-0619eb00e92ab7b00
+      MFES40AMI: ami-0ed05eb873c2da4ef
     eu-west-3:
-      MFES40AMI: ami-02eaa14fb48885cc9
+      MFES40AMI: ami-0dd39cc30ea3574b7
     sa-east-1:
-      MFES40AMI: ami-01bba1206e8807019
+      MFES40AMI: ami-082e4e947dbbf35b1
     us-east-1:
-      MFES40AMI: ami-0a4603cadffc7170d
+      MFES40AMI: ami-0e6255dfab3d7497c
     us-east-2:
-      MFES40AMI: ami-0a2b689af8ad19ff3
+      MFES40AMI: ami-048a75e3c74fdfa5f
     us-west-1:
-      MFES40AMI: ami-09577a4bbdc01a65d
+      MFES40AMI: ami-074e117de783cab22
     us-west-2:
-      MFES40AMI: ami-047e3be248b380812
+      MFES40AMI: ami-09dc8cff0a367fa32
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
@@ -396,6 +386,9 @@ Conditions:
     - 'true'
   InstallingSQLDemoApp: !Equals
     - !Ref InstallSQLDemoApp
+    - 'true'
+  InstallingPACDemoApp: !Equals
+    - !Ref InstallPACDemoApp
     - 'true'
   HaveDatabaseEnvironment: !Not
     - !Equals
@@ -499,7 +492,7 @@ Resources:
             var result = (parseInt(props.RegionsPerInstance) * parseInt(props.RegionStorageOverheadInGiB)) + parseInt(props.AdditionalESStorageinGiB);
             response.send(event, context, response.SUCCESS, {Value: result});
           };
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
   ESPrimaryDataVolumeStorageSize:
     Type: 'Custom::CalcPrimaryDataVolumeStorageSizeFunction'
     Properties:
@@ -524,7 +517,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT20M
+        Timeout: PT25M
     Metadata:
       'AWS::CloudFormation::Authentication':
         S3AccessCreds:
@@ -550,23 +543,35 @@ Resources:
               - 070-Setup-Database-Client-Environment
               - 000-NoOperation
             - !If
+              - InstallingPACDemoApp
+              - 080-Setup-PAC-Database-Envrionment
+              - 000-NoOperation
+            - !If
               - InstallingFSDemoApp
-              - 080-InstallBankDemoFS
+              - 090-InstallBankDemoFS
               - 000-NoOperation
             - !If
               - InstallingSQLDemoApp
-              - 090-InstallBankDemoSQL
+              - 100-InstallBankDemoSQL
               - 000-NoOperation
-            - 100-ChangeMFDSServiceStartName
+            - !If
+              - InstallingPACDemoApp
+              - 110-InstallBankDemoPAC
+              - 000-NoOperation
+            - 120-ChangeMFDSServiceStartName
             - !If
               - InstallingFSDemoApp
-              - 110-Start-BNKDMFS
+              - 130-Start-BNKDMFS
               - 000-NoOperation
             - !If
               - InstallingSQLDemoApp
-              - 120-Start-BNKDMSQL
+              - 140-Start-BNKDMSQL
               - 000-NoOperation
-            - 130-Finalize
+            - !If
+              - InstallingPACDemoApp
+              - 150-Start-BNKDM
+              - 000-NoOperation
+            - 160-Finalize
         000-NoOperation:
           commands:
             a-no-operation:
@@ -857,31 +862,87 @@ Resources:
                     -PathToAdd "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin"
               waitAfterCompletion: '0'
             b-configure-windows-firewall-es-admin-portal-rule:
-              command: !Sub
+              command:
                 powershell.exe
                   -Command New-NetFirewallRule
                     -DisplayName 'Micro Focus Enterprise Server Admin Portal'
-                    -LocalPort ${ESCCITCPListenerPort}
+                    -LocalPort 86
                     -Protocol tcp
               waitAfterCompletion: '0'
             c-configure-windows-firewall-fs-demoapp-tn3270-portal-rule:
               test: !Sub >-
                 if /I "${InstallFSDemoApp}"=="true" (exit 0) else (exit 1)
-              command: !Sub
+              command:
                 powershell.exe
                   -Command New-NetFirewallRule
                     -DisplayName 'FS Demo App TN3270 Ingress'
-                    -LocalPort ${FSDemoApp3270Port}
+                    -LocalPort 5555
                     -Protocol tcp
               waitAfterCompletion: '0'
             d-configure-windows-firewall-sql-demoapp-tn3270-portal-rule:
               test: !Sub >-
                 if /I "${InstallSQLDemoApp}"=="true" (exit 0) else (exit 1)
-              command: !Sub
+              command:
                 powershell.exe
                   -Command New-NetFirewallRule
                     -DisplayName 'SQLServer Demo App TN3270 Ingress'
-                    -LocalPort ${SQLDemoApp3270Port}
+                    -LocalPort 5556
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            e-configure-windows-firewall-pac-demoapp-tn3270-portal-rule:
+              test: !Sub >-
+                if /I "${InstallPACDemoApp}"=="true" (exit 0) else (exit 1)
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'SQLServer Demo App TN3270 Ingress'
+                    -LocalPort 5557
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            f-configure-windows-firewall-fs-demoapp-esmac-portal-rule:
+              test: !Sub >-
+                if /I "${InstallFSDemoApp}"=="true" (exit 0) else (exit 1)
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'FS esmac Ingress'
+                    -LocalPort 5558
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            g-configure-windows-firewall-sql-demoapp-esmac-portal-rule:
+              test: !Sub >-
+                if /I "${InstallSQLDemoApp}"=="true" (exit 0) else (exit 1)
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'SQLServer esmac Ingress'
+                    -LocalPort 5559
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            h-configure-windows-firewall-pac-demoapp-esmac-portal-rule:
+              test: !Sub >-
+                if /I "${InstallPACDemoApp}"=="true" (exit 0) else (exit 1)
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'PAC esmac Ingress'
+                    -LocalPort 5560
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            i-configure-windows-firewall-es-admin-portal-rule:
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'Micro Focus Enterprise Server Admin Portal'
+                    -LocalPort 86
+                    -Protocol udp
+              waitAfterCompletion: '0'
+            j-configure-windows-firewall-es-escwa-portal-rule:
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'Micro Focus Enterprise Server Admin Portal'
+                    -LocalPort 10004
                     -Protocol tcp
               waitAfterCompletion: '0'
         050-ApplyESLicenseFile:
@@ -895,6 +956,15 @@ Resources:
                     - s3-us-gov-west-1
                     - s3
               authentication: S3AccessCreds
+            'c:\cfn\scripts\MFDS-Listen-all.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/MFDS-Listen-all.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
           commands:
             a-install-license:
               cwd: 'C:\Program Files (x86)\Common Files\SafeNet Sentinel\Sentinel RMS License Manager\WinNT\'
@@ -903,6 +973,10 @@ Resources:
                   cesadmintool
                     -term install
                     -f d:\esdir\Enterprise-Server.mflic
+              waitAfterCompletion: '0'
+            b-set-MFDS-listen-all:
+              command:
+                powershell.exe -File C:\cfn\scripts\MFDS-Listen-all.ps1
               waitAfterCompletion: '0'
         060-RenameAndJoinDomain:
           commands:
@@ -980,7 +1054,48 @@ Resources:
                   -File c:\cfn\scripts\AddTo-SystemPath.ps1
                     -PathToAdd "c:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn"
               waitAfterCompletion: '0'
-        080-InstallBankDemoFS:
+        080-Setup-PAC-Database-Envrionment:
+          files:
+            'c:\cfn\assets\psqlodbc1_11_x86.zip':
+              source:
+                https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x86.zip
+            'c:\cfn\assets\psqlodbc1_11_x64.zip':
+              source:
+                https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x64.zip
+          commands:
+            a-Unzip-PsqlODBC-Driver-x86:
+              command:
+                powershell.exe
+                -File C:\cfn\scripts\Unzip-Archive.ps1
+                    -Source C:\cfn\assets\psqlodbc1_11_x86.zip
+                    -Destination C:\cfn\assets\psqlodbc_11_x86
+              waitAfterCompletion: '0'
+            b-Unzip-PsqlODBC-Driver-x64:
+              command:
+                powershell.exe
+                -File C:\cfn\scripts\Unzip-Archive.ps1
+                    -Source C:\cfn\assets\psqlodbc1_11_x64.zip
+                    -Destination C:\cfn\assets\psqlodbc_11_x64
+              waitAfterCompletion: '0'
+            c-install-PsqlODBC-Driver-x86:
+              command:
+                start /wait
+                  msiexec
+                    /quiet
+                    /passive
+                    /qn
+                    /i c:\cfn\assets\psqlodbc_11_x86\psqlodbc_x86.msi
+              waitAfterCompletion: '0'
+            d-install-PsqlODBC-Driver-x64:
+              command:
+                start /wait
+                  msiexec
+                    /quiet
+                    /passive
+                    /qn
+                    /i c:\cfn\assets\psqlodbc_11_x64\psqlodbc_x64.msi
+              waitAfterCompletion: '0'
+        090-InstallBankDemoFS:
           commands:
             a-import-region:
               cwd: C:\Program Files (x86)\Micro Focus\Enterprise Server\bin
@@ -991,7 +1106,7 @@ Resources:
                     C:\BankDemo_FS\Repo\BNKDMFS.xml
                     D
               waitAfterCompletion: '0'
-        090-InstallBankDemoSQL:
+        100-InstallBankDemoSQL:
           files:
             'c:\cfn\scripts\CreateDSN.ps1':
               content: |
@@ -1021,7 +1136,102 @@ Resources:
                     C:\BankDemo_SQL\BNKDMSQLRegionDefForImport\BNKDMSQL.xml
                     D
               waitAfterCompletion: '0'
-        100-ChangeMFDSServiceStartName:
+        110-InstallBankDemoPAC:
+          files:
+            'C:\cfn\scripts\deploy.bat':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/deploy.bat
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\scripts\configure-and-import-pac-region.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/configure-and-import-pac-region.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\scripts\Add-region-to-PAC.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Add-region-to-PAC.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\CreateDSN_PAC.ps1':
+              content: !Sub |
+                try{
+                  # Create ODBC DNS to the BankDemo database
+                  Add-OdbcDsn `
+                      -Name PG.VSAM `
+                      -DriverName "PostgreSQL ANSI" `
+                      -DsnType "System" `
+                      -Platform "32-bit" `
+                      -SetPropertyValue @("Server=ESPACDatabase", "UserName=esuser", 'Database=MicroFocus$SEE$Files$VSAM', "Password=${PACDBMasterUserPassword}")
+
+                  Add-OdbcDsn `
+                      -Name PG.POSTGRES `
+                      -DriverName "PostgreSQL ANSI" `
+                      -DsnType "System" `
+                      -Platform "32-bit" `
+                      -SetPropertyValue @("Server=ESPACDatabase", "UserName=esuser", "Database=postgres", "Password=${PACDBMasterUserPassword}")
+                  
+                  Add-OdbcDsn `
+                      -Name PG.REGION `
+                      -DriverName "PostgreSQL ANSI" `
+                      -DsnType "System" `
+                      -Platform "32-bit" `
+                      -SetPropertyValue @("Server=ESPACDatabase", "UserName=esuser", 'Database=MicroFocus$CAS$Region$DEMOPAC', "Password=${PACDBMasterUserPassword}")
+
+                  Add-OdbcDsn `
+                      -Name PG.CROSSREGION `
+                      -DriverName "PostgreSQL ANSI" `
+                      -DsnType "System" `
+                      -Platform "32-bit" `
+                      -SetPropertyValue @("Server=ESPACDatabase", "UserName=esuser", 'Database=MicroFocus$CAS$CrossRegion', "Password=${PACDBMasterUserPassword}")
+                } catch {
+                  $_ | Write-AWSQuickStartException
+                }
+          commands:
+            a-CreateDSN:
+              command:
+                powershell.exe
+                  -File c:\cfn\scripts\CreateDSN_PAC.ps1
+              waitAfterCompletion: '0'
+            b-configure-and-import-region1:
+              test: !Sub >-
+                if /I "${ESInstanceName}"=="ESSERVER1" (exit 0) else (exit 1)
+              cwd: C:\Program Files (x86)\Micro Focus\Enterprise Server\bin
+              command:
+                powershell.exe -File c:\cfn\scripts\configure-and-import-pac-region.ps1 -Regionname BNKDM
+              waitAfterCompletion: '0'
+            c-configure-and-import-region2:
+              test: !Sub >-
+                if /I "${ESInstanceName}"=="ESSERVER2" (exit 0) else (exit 1)
+              cwd: C:\Program Files (x86)\Micro Focus\Enterprise Server\bin
+              command:
+                powershell.exe -File c:\cfn\scripts\configure-and-import-pac-region.ps1 -Regionname BNKDM2
+            d-import-data-files:
+              cwd: C:\Program Files (x86)\Micro Focus\Enterprise Server\bin
+              test: !Sub >-
+                if /I "${ESInstanceName}"=="ESSERVER1" (exit 0) else (exit 1)
+              command:
+                start /wait c:\cfn\scripts\deploy.bat
+              waitAfterCompletion: '0'
+            e-add-region-to-PAC:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Add-region-to-PAC.ps1
+                  -ESInstanceName ${ESInstanceName}
+              waitAfterCompletion: '0'
+        120-ChangeMFDSServiceStartName:
           files:
             'c:\cfn\scripts\Configure-UserLogonPrivileges.ps1':
               source: !Sub
@@ -1036,6 +1246,15 @@ Resources:
               source: !Sub
                 - >-
                   https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Change-NTServiceStartName.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\scripts\Configure-ESCWA.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Configure-ESCWA.ps1
                 - QSS3Region: !If
                     - GovCloudCondition
                     - s3-us-gov-west-1
@@ -1058,7 +1277,12 @@ Resources:
                     -PrivilegeName "SeBatchLogonRight"
                     -Status Grant
               waitAfterCompletion: '0'
-            c-change-mfds-service-startname:
+            c-grant-mfds-account-permissions:
+              cwd: C:\ProgramData
+              command: !Sub
+                icacls "C:\ProgramData\Micro Focus" /grant ${DomainNetBIOSName}\${MFDSServiceAccountName}:(OI)(CI)F /T
+              waitAfterCompletion: '0'
+            d-change-mfds-service-startname:
               command: !Sub
                 powershell.exe
                   -File c:\cfn\scripts\Change-NTServiceStartName.ps1
@@ -1066,7 +1290,23 @@ Resources:
                     -StartName "${DomainNetBIOSName}\${MFDSServiceAccountName}"
                     -StartPassword ${MFDSServiceAccountPassword}
               waitAfterCompletion: '0'
-        110-Start-BNKDMFS:
+            e-configure-escwa:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-ESCWA.ps1
+                  -DomainNetBIOSName ${DomainNetBIOSName}
+                  -ServiceUser ${MFDSServiceAccountName}
+                  -ServicePassword ${MFDSServiceAccountPassword}
+              waitAfterCompletion: '0'
+            f-grant-ESDemouser-account-remote-logon:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-UserLogonPrivileges.ps1
+                    -Username "${DomainNetBIOSName}\ESDemoUser"
+                    -PrivilegeName "SeRemoteInteractiveLogonRight"
+                    -Status Grant
+              waitAfterCompletion: '0'
+        130-Start-BNKDMFS:
           commands:
             a-start-BNKDMFS-region:
               command: !Sub
@@ -1077,7 +1317,7 @@ Resources:
                     -DomainUserName "${DomainNetBIOSName}\${MFDSServiceAccountName}"
                     -DomainUserPassword "${MFDSServiceAccountPassword}"
               waitAfterCompletion: '0'
-        120-Start-BNKDMSQL:
+        140-Start-BNKDMSQL:
           commands:
             a-start-BNKDMSQL-region:
               command: !Sub
@@ -1088,7 +1328,41 @@ Resources:
                     -DomainUserName "${DomainNetBIOSName}\${MFDSServiceAccountName}"
                     -DomainUserPassword "${MFDSServiceAccountPassword}"
               waitAfterCompletion: '0'
-        130-Finalize:
+        150-Start-BNKDM:
+          files:
+            'c:\cfn\scripts\StartESRegion-cold.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/StartESRegion-cold.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          commands:
+            a-start-BNKDM-region:
+              test: !Sub >-
+                if /I "${ESInstanceName}"=="ESSERVER1" (exit 0) else (exit 1)
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1
+                    -TaskName startBNKDM
+                    -TaskArguments "-File c:\cfn\scripts\StartESRegion-cold.ps1 -RegionName BNKDM"
+                    -DomainUserName "${DomainNetBIOSName}\${MFDSServiceAccountName}"
+                    -DomainUserPassword "${MFDSServiceAccountPassword}"
+              waitAfterCompletion: '0'
+            b-start-BNKDM2-region:
+              test: !Sub >-
+                if /I "${ESInstanceName}"=="ESSERVER2" (exit 0) else (exit 1)
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1
+                    -TaskName startBNKDM
+                    -TaskArguments "-File c:\cfn\scripts\StartESRegion.ps1 -RegionName BNKDM2 -Delay yes"
+                    -DomainUserName "${DomainNetBIOSName}\${MFDSServiceAccountName}"
+                    -DomainUserPassword "${MFDSServiceAccountPassword}"
+              waitAfterCompletion: '0'
+        160-Finalize:
           commands:
             a-finalize-init:
               command:

--- a/templates/mf-es-workload-template.yaml
+++ b/templates/mf-es-workload-template.yaml
@@ -52,14 +52,18 @@ Metadata:
         Parameters:
           - RDGWAccessSGID
       - Label:
+          default: Linux Bastion Configuration
+        Parameters:
+          - BastionAccessSGID
+      - Label:
           default: Enterprise Server Configuration
         Parameters:
+          - OS
           - ESInstanceType
           - NumberOfESInstance
           - KeyPairName
           - RegionsPerInstance
           - AdditionalESStorageinGiB
-          - ESCCITCPListenerPort
           - ESCWLogGroupRetentionInDays
           - MFDSServiceAccountName
           - MFDSServiceAccountPassword
@@ -68,13 +72,21 @@ Metadata:
           - ESS3BucketName
           - ESResourceNamePrefix
       - Label:
+          default: PAC Configuration
+        Parameters:
+          - InstallPACDemoApp
+          - PACDBInstanceClass
+          - PACDBMasterUsername
+          - PACDBMasterUserPassword
+          - PACDBMasterUserPasswordConfirm
+          - PACDBStorageInGiB
+      - Label:
           default: Enterprise Server Fileshare Configuration
         Parameters:
           - FileshareType
           - InstallFSDemoApp
           - FSInstanceType
           - FSStorageInGiB
-          - FSCCITCPListenerPort
           - FSVIEWUserPassword
           - FSVIEWUserPasswordConfirm
       - Label:
@@ -97,8 +109,6 @@ Metadata:
           - ESDemoUserPassword
           - ESDemoUserPasswordConfirm
           - DemoAppsIngressCIDR
-          - FSDemoApp3270Port
-          - SQLDemoApp3270Port
       - Label:
           default: AWS Quick Start Configuration
         Parameters:
@@ -109,6 +119,8 @@ Metadata:
         default: Additional Enterprise Server instance storage
       AvailabilityZones:
         default: Availability Zones
+      BastionAccessSGID:
+        default: Bastion Security Group ID
       DatabaseType:
         default: Database type
       DBBackupRetentionPeriod:
@@ -143,14 +155,14 @@ Metadata:
         default: Domain member Security Group ID
       DomainNetBIOSName:
         default: Domain NetBIOS name
-      ESCCITCPListenerPort:
-        default: Enterprise Server CCITCP listener port
       ESCWLogGroupRetentionInDays:
         default: Amazon CloudWatch log retention
       ESDemoUserPassword:
         default: Enterprise Server Demo User password
       ESDemoUserPasswordConfirm:
         default: Re-enter the Enterprise Server Demo User password
+      OS:
+        default: Enterprise Server instance(s) OS type
       ESInstanceType:
         default: Enterprise Server instance type
       ESLicenseFilename:
@@ -163,12 +175,8 @@ Metadata:
         default: Fileshare type
       FSInstanceType:
         default: Enterprise Server Fileshare instance type
-      FSCCITCPListenerPort:
-        default: Enterprise Server Fileshare CCITCP listener port
       FSStorageInGiB:
         default: Fileshare allocated storage size
-      FSDemoApp3270Port:
-        default: Fileshare Bank Demo TN3270 Port
       FSVIEWUserPassword:
         default: FSVIEW user password
       FSVIEWUserPasswordConfirm:
@@ -177,6 +185,8 @@ Metadata:
         default: Install Fileshare Demo App
       InstallSQLDemoApp:
         default: Install SQLServer Demo App
+      InstallPACDemoApp:
+        default: Install PAC Demo App
       KeyPairName:
         default: Key pair name
       LicenseAgreement:
@@ -191,6 +201,16 @@ Metadata:
         default: Number of Enterprise Server instances
       OperatorEmail:
         default: Operator email address
+      PACDBInstanceClass:
+        default: PAC database instance class
+      PACDBMasterUsername: 
+        default: PAC database Master username
+      PACDBMasterUserPassword:
+        default: PAC database Master password
+      PACDBMasterUserPasswordConfirm:
+        default: Re-enter the PAC database Master password
+      PACDBStorageInGiB:
+        default: Database allocated storage size
       PrivateSubnet1AID:
         default: Private Subnet 1A ID
       PrivateSubnet2AID:
@@ -207,8 +227,6 @@ Metadata:
         default: RD Gateway Security Group ID
       RegionsPerInstance:
         default: Number of Enterprise Server regions per instance
-      SQLDemoApp3270Port:
-        default: SQLServer Bank Demo TN3270 Port
       VPCID:
         default: VPC ID
 Parameters:
@@ -226,6 +244,10 @@ Parameters:
       Quick Start uses two Availability Zones from your list and preserves the
       logical order you specify.
     Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  BastionAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: >-
+      The security group ID for access from the Bastion host.
   DatabaseType:
     AllowedValues:
       - None
@@ -273,8 +295,8 @@ Parameters:
       printable ASCII character except "/", """, or "@".
     Description: >-
       The password for the DB master user. Must be at least eight characters
-      long, as in "mypassword". Can be any printable ASCII character except
-      "/", """, or "@".
+      long, as in "mypassword". Can be any printable ASCII character 
+      except "/", """, or "@".
     Type: String
     NoEcho: true
   DBMasterUserPasswordConfirm:
@@ -291,12 +313,12 @@ Parameters:
     NoEcho: true
   DBPreferredBackupWindow:
     Description: >-
-      Must be in the format hh24:mi-hh24:mi, in UTC. Must be at least 30
+      (optional) Must be in the format hh24:mi-hh24:mi, in UTC. Must be at least 30
       minutes, and must not conflict with the preferred maintenance window.
     Type: String
   DBPreferredMaintenanceWindow:
     Description: >-
-      Must be in the format ddd:hh24:mi-ddd:hh24:mi, in UTC. Must be at least 30
+      (optional) Must be in the format ddd:hh24:mi-ddd:hh24:mi, in UTC. Must be at least 30
       minutes.
     Type: String
   DBStorageInGiB:
@@ -367,13 +389,6 @@ Parameters:
       earlier versions of Microsoft Windows, e.g., example.
     MaxLength: '15'
     Type: String
-  ESCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535
-    Default: 86
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
   ESCWLogGroupRetentionInDays:
     Default: 7
     Description: The number of days that log events are kept in Amazon CloudWatch Logs.
@@ -406,6 +421,64 @@ Parameters:
     MinLength: '8'
     NoEcho: true
     Type: String
+  OS:
+    AllowedValues:
+      - Windows
+      - Red Hat Enterprise Linux
+    Description: The operating system type for the Enterprise Server instance(s).
+    Default: Windows
+    Type: String
+  PACDBInstanceClass:
+    AllowedValues:
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r2.8xlarge
+    Description: The type of Amazon RDS DB instance.
+    Default: db.r4.large
+    Type: String
+  PACDBMasterUsername:
+    Description: >-
+      Specify an alphanumeric string that defines the login ID for the master
+      user in the PAC database. Master user name must start with a letter. Must contain 1 to 64
+      alphanumeric characters.
+    AllowedPattern: >-
+      ^[a-zA-Z][a-zA-Z0-9]{1,64}$
+    ConstraintDescription: >-
+      Must start with a letter. Must contain 1 to 64 alphanumeric characters.
+    Default: DBAdmin
+    Type: String
+  PACDBMasterUserPassword:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      The password for the DB master user in the PAC database. Must be at least eight characters
+      long, as in "mypassword". Can be any printable ASCII character except
+      "/", """, or "@".
+    Type: String
+    NoEcho: true
+  PACDBMasterUserPasswordConfirm:
+    AllowedPattern: >-
+      ^((?![\/"@])[^\x00-\x1F\x80-\x9F]){8,}$
+    ConstraintDescription: >-
+      Must be at least eight characters long, as in "mypassword". Can be any
+      printable ASCII character except "/", """, or "@".
+    Description: >-
+      Confirm the password for the DB master user in the PAC database. Must be at least eight
+      characters long, as in "mypassword". Can be any printable ASCII character
+      except "/", """, or "@".
+    Type: String
+    NoEcho: true
+  PACDBStorageInGiB:
+    Type: Number
+    Description: Enter 20-16384 GiB.
+    MinValue: 20
+    MaxValue: 16384
+    Default: 100
   ESInstanceType:
     AllowedValues:
       - c5.large
@@ -424,7 +497,7 @@ Parameters:
     Default: 'AWS::StackName'
     Description: >-
       Used to prefix resource 'Name' tags. Leave empty for no prefix.
-      Otherwise, use 'AWS::StackName' or a value such as the parent stack's
+      Otherwise, use 'AWS::StackName' or a value such as the parent stacks
       name.
     Type: String
   ESS3BucketName:
@@ -444,20 +517,6 @@ Parameters:
     Description: >-
       If you choose 'None', the remaining Fileshare Configuration parameters
       are ignored.
-    Type: String
-  FSCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535
-    Default: 3000
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
-  FSDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5555'
     Type: String
   FSInstanceType:
     AllowedValues:
@@ -502,6 +561,15 @@ Parameters:
     MinLength: '8'
     NoEcho: true
     Type: String
+  InstallPACDemoApp:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: >-
+      Choose 'false' if you don't want to install the Enterprise Server PAC demo
+      app.
   InstallFSDemoApp:
     Type: String
     AllowedValues:
@@ -638,41 +706,40 @@ Parameters:
     MaxValue: 10
     MinValue: 1
     Type: Number
-  SQLDemoApp3270Port:
-    AllowedPattern: >-
-      ^([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-    ConstraintDescription: Must be a number (1-65535).
-    Description: The TN3270 port must be a number (1-65535).
-    Default: '5349'
-    Type: String
   VPCID:
     Description: ID of your existing VPC for deployment.
     Type: 'AWS::EC2::VPC::Id'
 Rules:
-#  DBMasterUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref DBMasterUserPassword
-#          - !Ref DBMasterUserPasswordConfirm
-#        AssertDescription: Database Master password values do not match.
-#  DomainAdminPasswordsMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref DomainAdminPassword
-#          - !Ref DomainAdminPasswordConfirm
-#        AssertDescription: Domain Admin account password values do not match.
-#  ESDemoUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref ESDemoUserPassword
-#          - !Ref ESDemoUserPasswordConfirm
-#        AssertDescription: Enterprise Server Demo user password values do not match.
-#  FSVIEWUserPasswordMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref FSVIEWUserPassword
-#          - !Ref FSVIEWUserPasswordConfirm
-#        AssertDescription: FSVIEW user password values do not match.
+  DBMasterUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref DBMasterUserPassword
+          - !Ref DBMasterUserPasswordConfirm
+        AssertDescription: Database Master password values do not match.
+  DomainAdminPasswordsMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref DomainAdminPassword
+          - !Ref DomainAdminPasswordConfirm
+        AssertDescription: Domain Admin account password values do not match.
+  ESDemoUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref ESDemoUserPassword
+          - !Ref ESDemoUserPasswordConfirm
+        AssertDescription: Enterprise Server Demo user password values do not match.
+  FSVIEWUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref FSVIEWUserPassword
+          - !Ref FSVIEWUserPasswordConfirm
+        AssertDescription: FSVIEW user password values do not match.
+  PACDBMasterUserPasswordMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref PACDBMasterUserPassword
+          - !Ref PACDBMasterUserPasswordConfirm
+        AssertDescription: The PAC database Master password values do not match.
   InstallFSDemoAppRule:
     RuleCondition: !Equals
       - !Ref InstallFSDemoApp
@@ -711,12 +778,75 @@ Rules:
             - - I agree
             - !Ref LicenseAgreement
         AssertDescription: User must agree to the terms of the license agreement.
-#  MFDSServiceAccountPasswordsMatchRule:
-#    Assertions:
-#      - Assert: !Equals
-#          - !Ref MFDSServiceAccountPassword
-#          - !Ref MFDSServiceAccountPasswordConfirm
-#        AssertDescription: The Micro Focus Directory Server, Service Account password values do not match.
+  MFDSServiceAccountPasswordsMatchRule:
+    Assertions:
+      - Assert: !Equals
+          - !Ref MFDSServiceAccountPassword
+          - !Ref MFDSServiceAccountPasswordConfirm
+        AssertDescription: The Micro Focus Directory Server, Service Account password values do not match.
+  RDSWinAthSupportedRegionRule:
+    RuleCondition: !Equals
+      - !Ref DatabaseType
+      - Create-RDS-Remote-Database
+    Assertions:
+      - Assert: !Contains
+          - - us-east-2          # US East (Ohio)
+            - us-east-1          # US East (N. Virginia)
+            # - us-west-1          # US West (N. California) --> RDS-WinAuth not supported 2020-Feb-07
+            - us-west-2          # US West (Oregon)
+            - ap-east-1          # Asia Pacific (Hong Kong)
+            # - ap-south-1         # Asia Pacific (Mumbai) --> RDS-WinAuth not supported 2020-Feb-07
+            - ap-northeast-3     # Asia Pacific (Osaka-Local)
+            - ap-northeast-2     # Asia Pacific (Seoul)
+            - ap-southeast-1     # Asia Pacific (Singapore)
+            - ap-southeast-2     # Asia Pacific (Sydney)
+            - ap-northeast-1     # Asia Pacific (Tokyo)
+            - ca-central-1       # Canada (Central)
+            - cn-north-1         # China (Beijing)
+            - cn-northwest-1     # China (Ningxia)
+            - eu-central-1       # Europe (Frankfurt)
+            - eu-west-1          # Europe (Ireland)
+            - eu-west-2          # Europe (London)
+            - eu-west-3          # Europe (Paris)
+            - eu-north-1         # Europe (Stockholm)
+            - me-south-1         # Middle East (Bahrain)
+            # - sa-east-1          # South America (Sao Paulo) --> RDS-WinAuth not supported 2020-Feb-07
+            # - us-gov-east-1      # AWS GovCloud (US-East) --> RDS-WinAuth not supported 2020-Feb-07
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> RDS-WinAuth not supported 2020-Feb-07
+          - !Ref AWS::Region
+        AssertDescription: This Quick Start utilizes Amazon Relational Database Service (Amazon RDS) Windows
+          Authentication which is not available in the chosen region. Please refer to
+          https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_SQLServerWinAuth.html
+          for more details and launch the stack in one of the supported regions.
+  ESSupportedRegionRule:
+    Assertions:
+      - Assert: !Contains
+          - - us-east-2          # US East (Ohio)
+            - us-east-1          # US East (N. Virginia)
+            - us-west-1          # US West (N. California)
+            - us-west-2          # US West (Oregon)
+            #- ap-east-1          # Asia Pacific (Hong Kong) --> MFES not available
+            - ap-south-1         # Asia Pacific (Mumbai)
+            # - ap-northeast-3     # Asia Pacific (Osaka-Local) --> Osaka-Local not supported
+            - ap-northeast-2     # Asia Pacific (Seoul)
+            - ap-southeast-1     # Asia Pacific (Singapore)
+            - ap-southeast-2     # Asia Pacific (Sydney)
+            - ap-northeast-1     # Asia Pacific (Tokyo)
+            - ca-central-1       # Canada (Central)
+            # - cn-north-1         # China (Beijing) --> MFES not available
+            # - cn-northwest-1     # China (Ningxia) --> MFES not available
+            - eu-central-1       # Europe (Frankfurt)
+            - eu-west-1          # Europe (Ireland)
+            - eu-west-2          # Europe (London)
+            - eu-west-3          # Europe (Paris)
+            - eu-north-1         # Europe (Stockholm)
+            #- me-south-1         # Middle East (Bahrain) --> MFES not available
+            - sa-east-1          # South America (Sao Paulo)
+            # - us-gov-east-1      # AWS GovCloud (US-East) --> GovCloud not supported
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported 
+          - !Ref AWS::Region
+        AssertDescription: Micro Focus is not currently supporting this Quick Start in 
+          the chosen region. Please contact Micro Focus or launch into a different region.
 Conditions:
   CreateRDSRemoteDatabaseStack: !Equals
     - !Ref DatabaseType
@@ -734,6 +864,10 @@ Conditions:
   InstallingAtLeastOneDemoApp: !Or
     - !Condition InstallingFSDemoApp
     - !Condition InstallingSQLDemoApp
+    - !Condition InstallingPACDemoApp
+  InstallingPACDemoApp: !Equals
+    - !Ref InstallPACDemoApp
+    - 'true'
   InstallingFSDemoApp: !Equals
     - !Ref InstallFSDemoApp
     - 'true'
@@ -746,9 +880,30 @@ Conditions:
   NamePrefixIsUndefined: !Equals
     - !Ref ESResourceNamePrefix
     - ''
-  Start2Instances: !Equals
+  2InstancesSelected: !Equals
     - !Ref NumberOfESInstance
     - 2
+  Start2Instances: !Or
+    - !Condition 2InstancesSelected
+    - !Condition InstallingPACDemoApp
+  OSRedhat: !Equals
+    - !Ref OS
+    - 'Red Hat Enterprise Linux'
+  OSWindows: !Equals
+    - !Ref OS
+    - 'Windows'
+  Start2RedhatInstances: !And
+    - !Condition Start2Instances
+    - !Condition OSRedhat
+  Start2WindowsInstances: !And
+    - !Condition Start2Instances
+    - !Condition OSWindows
+  CreateWinRemoteFileshareStack: !And
+    - !Condition CreateRemoteFileshareServerStack
+    - !Condition OSWindows
+  CreateRedhatRemoteFileshareStack: !And
+    - !Condition CreateRemoteFileshareServerStack
+    - !Condition OSRedhat
 Resources:
   EMailNotificationTopic:
     Type: 'AWS::SNS::Topic'
@@ -802,7 +957,46 @@ Resources:
         VPCID: !Ref VPCID
   RemoteFileshareServerStack:
     Type: 'AWS::CloudFormation::Stack'
-    Condition: CreateRemoteFileshareServerStack
+    Condition: CreateRedhatRemoteFileshareStack
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/mf-fs-redhat-template.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AvailabilityZones: !Join
+          - ','
+          - !Ref AvailabilityZones
+        DomainAdminPassword: !Ref DomainAdminPassword
+        DomainDNSName: !Ref DomainDNSName
+        DomainMemberSGID: !Ref DomainMemberSGID
+        ESCWLogGroup: !Ref ESCWLogGroup
+        ESLicenseFilename: !Ref ESLicenseFilename
+        ESResourceNamePrefix: !Ref ESResourceNamePrefix
+        ESS3BucketName: !Ref ESS3BucketName
+        FSClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        FSInstanceType: !Ref FSInstanceType
+        FSServerName: FSServer
+        FSStorageInGiB: !Ref FSStorageInGiB
+        FSVIEWUserPassword: !Ref FSVIEWUserPassword
+        InstallDemoApps: !Ref InstallFSDemoApp
+        KeyPairName: !Ref KeyPairName
+        LicenseAgreement: !Ref LicenseAgreement
+        NotificationARN: !If
+          - HaveOperatorEmail
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+        PrivateSubnet1AID: !Ref PrivateSubnet1AID
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        BastionAccessSGID: !Ref BastionAccessSGID
+        VPCID: !Ref VPCID
+  RemoteFileshareWinServerStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: CreateWinRemoteFileshareStack
     Properties:
       TemplateURL: !Sub
         - >-
@@ -823,7 +1017,6 @@ Resources:
         ESLicenseFilename: !Ref ESLicenseFilename
         ESResourceNamePrefix: !Ref ESResourceNamePrefix
         ESS3BucketName: !Ref ESS3BucketName
-        FSCCITCPListenerPort: !Ref FSCCITCPListenerPort
         FSClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
         FSInstanceType: !Ref FSInstanceType
         FSServerName: FSServer
@@ -840,6 +1033,31 @@ Resources:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         RDGWAccessSGID: !Ref RDGWAccessSGID
+        VPCID: !Ref VPCID
+  AuroraServerStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: InstallingPACDemoApp
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/mf-db-aurora-template.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        DBInstanceClass: !Ref PACDBInstanceClass
+        DBMasterUsername: !Ref PACDBMasterUsername
+        DBMasterUserPassword: !Ref PACDBMasterUserPassword
+        DirectoryServiceID: !Ref DirectoryServiceID
+        ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        ESResourceNamePrefix: !Ref ESResourceNamePrefix
+        NotificationARN: !If
+          - HaveOperatorEmail
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+        PrivateSubnet1AID: !Ref PrivateSubnet1AID
+        PrivateSubnet2AID: !Ref PrivateSubnet2AID
         VPCID: !Ref VPCID
   ESInstanceRole:
     Type: 'AWS::IAM::Role'
@@ -921,20 +1139,35 @@ Resources:
         - !Ref NoRDSRemoteDatabaseStackCreateWaitHandle
       Timeout: '1'
       Count: 0
-  FSServerCreateWaitHandle:
-    Condition: CreateRemoteFileshareServerStack
+  FSServerWinCreateWaitHandle:
+    Condition: CreateWinRemoteFileshareStack
     DependsOn:
-      - RemoteFileshareServerStack
+      - RemoteFileshareWinServerStack
       - RDSRemoteDatabaseStackCreateWaitCondition
     Type: 'AWS::CloudFormation::WaitConditionHandle'
   NoFSServerWaitHandle:
     Type: 'AWS::CloudFormation::WaitConditionHandle'
-  FSServerWaitCondition:
+  FSServerWinWaitCondition:
     Type: 'AWS::CloudFormation::WaitCondition'
     Properties:
       Handle: !If
-        - CreateRemoteFileshareServerStack
-        - !Ref FSServerCreateWaitHandle
+        - CreateWinRemoteFileshareStack
+        - !Ref FSServerWinCreateWaitHandle
+        - !Ref NoFSServerWaitHandle
+      Timeout: '1'
+      Count: 0
+  FSServerRedhatCreateWaitHandle:
+    Condition: CreateRedhatRemoteFileshareStack
+    DependsOn:
+      - RemoteFileshareServerStack
+      - RDSRemoteDatabaseStackCreateWaitCondition
+    Type: 'AWS::CloudFormation::WaitConditionHandle'
+  FSServerRedhatWaitCondition:
+    Type: 'AWS::CloudFormation::WaitCondition'
+    Properties:
+      Handle: !If
+        - CreateRedhatRemoteFileshareStack
+        - !Ref FSServerRedhatCreateWaitHandle
         - !Ref NoFSServerWaitHandle
       Timeout: '1'
       Count: 0
@@ -958,9 +1191,19 @@ Resources:
             Allows access to the Enterprise Server Admin portal from the Remote
             Desktop Gateway instances
           IpProtocol: tcp
-          FromPort: !Ref ESCCITCPListenerPort
-          ToPort: !Ref ESCCITCPListenerPort
+          FromPort: 86
+          ToPort: 86
           SourceSecurityGroupId: !Ref RDGWAccessSGID
+        - !If
+          - OSRedhat
+          - Description: >-
+              Allows access to the Enterprise Server Admin portal from the Bastion
+              hosts
+            IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            SourceSecurityGroupId: !Ref BastionAccessSGID
+          - !Ref 'AWS::NoValue'
         - !If
           - InstallingAtLeastOneDemoApp
           - Description: Allow ICMP Destination Unreachable to aid MTU Path Discovery
@@ -973,22 +1216,59 @@ Resources:
           - InstallingFSDemoApp
           - Description: Fileshare Bank Demo Application TN3270 Listener Ingress
             IpProtocol: tcp
-            FromPort: !Ref FSDemoApp3270Port
-            ToPort: !Ref FSDemoApp3270Port
+            FromPort: 5555
+            ToPort: 5555
             CidrIp: !Ref DemoAppsIngressCIDR
           - !Ref 'AWS::NoValue'
         - !If
           - InstallingSQLDemoApp
           - Description: SQLServer Bank Demo Application TN3270 Listener Ingress
             IpProtocol: tcp
-            FromPort: !Ref SQLDemoApp3270Port
-            ToPort: !Ref SQLDemoApp3270Port
+            FromPort: 5556
+            ToPort: 5556
             CidrIp: !Ref DemoAppsIngressCIDR
           - !Ref 'AWS::NoValue'
+        - !If
+          - InstallingPACDemoApp
+          - Description: PAC Bank Demo Application TN3270 Listener Ingress
+            IpProtocol: tcp
+            FromPort: 5557
+            ToPort: 5557
+            CidrIp: !Ref DemoAppsIngressCIDR
+          - !Ref 'AWS::NoValue'
+  ElasticacheSecurityGroup:
+    Condition: InstallingPACDemoApp
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref VPCID
+      GroupDescription: "Elasticache Security Group"
+      SecurityGroupIngress:
+        -
+          IpProtocol: "tcp"
+          FromPort: 6379
+          ToPort: 6379
+          SourceSecurityGroupId: !Ref ESInstance1ClientAccessSecurityGroup
+  ElasticacheSubnetGroup1:
+    Condition: InstallingPACDemoApp
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: "Elasticache Subnet Group"
+      SubnetIds: [!Ref PrivateSubnet1AID]
+  Elasticache1:
+    Condition: InstallingPACDemoApp
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      AutoMinorVersionUpgrade: true
+      CacheSubnetGroupName: !Ref ElasticacheSubnetGroup1
+      Engine: "redis"
+      CacheNodeType: "cache.t2.micro"
+      NumCacheNodes: 1
+      VpcSecurityGroupIds: [!Ref ElasticacheSecurityGroup,]
   BootstrapStack:
     Type: 'AWS::CloudFormation::Stack'
     DependsOn:
-      - FSServerWaitCondition
+      - FSServerRedhatWaitCondition
+      - FSServerWinWaitCondition
       - RDSRemoteDatabaseStackCreateWaitCondition
     Properties:
       TemplateURL: !Sub
@@ -1004,6 +1284,8 @@ Resources:
           - !Ref AvailabilityZones
         DBMasterUsername: !Ref DBMasterUsername
         DBMasterUserPassword: !Ref DBMasterUserPassword
+        PACDBMasterUsername: !Ref PACDBMasterUsername
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
         DomainAdminPassword: !Ref DomainAdminPassword
         DomainDNSName: !Ref DomainDNSName
         DomainMemberSGID: !Ref DomainMemberSGID
@@ -1014,22 +1296,155 @@ Resources:
           - CreateRDSRemoteDatabaseStack
           - !GetAtt RemoteDatabaseServerStack.Outputs.ESDatabaseEndpointAddress
           - !Ref 'AWS::NoValue'
+        ESPACDatabaseEndpointAddress: !If
+          - InstallingPACDemoApp
+          - !GetAtt AuroraServerStack.Outputs.ESPACDatabaseEndpointAddress
+          - !Ref 'AWS::NoValue'
         ESS3BucketName: !Ref ESS3BucketName
         FileshareDataFolderUNC: !If
-          - CreateRemoteFileshareServerStack
-          - !GetAtt RemoteFileshareServerStack.Outputs.FileshareDataFolderUNC
+          - CreateWinRemoteFileshareStack
+          - !GetAtt RemoteFileshareWinServerStack.Outputs.FileshareDataFolderUNC
           - !Ref 'AWS::NoValue'
         InstallFSDemoApp: !Ref InstallFSDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
         InstallSQLDemoApp: !Ref InstallSQLDemoApp
         KeyPairName: !Ref KeyPairName
         MFDSServiceAccountName: !Ref MFDSServiceAccountName
         MFDSServiceAccountPassword: !Ref MFDSServiceAccountPassword
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        RedisEndPoint: !If
+          - InstallingPACDemoApp
+          - !GetAtt Elasticache1.RedisEndpoint.Address
+          - !Ref 'AWS::NoValue'
         SubnetID: !Ref PrivateSubnet1AID
-  ESInstanceStack1:
+  ESCWAStack:
     Type: 'AWS::CloudFormation::Stack'
     DependsOn:
+      - BootstrapStack
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/mf-escwa-template.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AvailabilityZones: !Join
+          - ','
+          - !Ref AvailabilityZones
+        DomainAdminPassword: !Ref DomainAdminPassword
+        DomainDNSName: !Ref DomainDNSName
+        DomainMemberSGID: !Ref DomainMemberSGID
+        DomainNetBIOSName: !Ref DomainNetBIOSName
+        EMailNotificationTopic: !If
+          - HaveOperatorEmail
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+        ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        ESCWLogGroup: !Ref ESCWLogGroup
+        ESCWAInstanceType: !Ref ESInstanceType
+        ESLicenseFilename: !Ref ESLicenseFilename
+        ESS3BucketName: !Ref ESS3BucketName
+        KeyPairName: !Ref KeyPairName
+        LicenseAgreement: !Ref LicenseAgreement
+        MFDSServiceAccountName: !Ref MFDSServiceAccountName
+        MFDSServiceAccountPassword: !Ref MFDSServiceAccountPassword
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        SubnetID: !Ref PrivateSubnet1AID
+  ESInstanceStack1:
+    Condition: OSRedhat
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ESCWAStack
+      - BootstrapStack
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/mf-es-redhat-template.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AvailabilityZones: !Join
+          - ','
+          - !Ref AvailabilityZones
+        DomainAdminPassword: !Ref DomainAdminPassword
+        DomainDNSName: !Ref DomainDNSName
+        DomainMemberSGID: !Ref DomainMemberSGID
+        DBMasterUserPassword: !Ref DBMasterUserPassword
+        EMailNotificationTopic: !If
+          - HaveOperatorEmail
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+        ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        ESCWLogGroup: !Ref ESCWLogGroup
+        ESInstanceName: ESServer1
+        ESInstanceType: !Ref ESInstanceType
+        ESLicenseFilename: !Ref ESLicenseFilename
+        ESS3BucketName: !Ref ESS3BucketName
+        InstallFSDemoApp: !Ref InstallFSDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
+        InstallSQLDemoApp: !Ref InstallSQLDemoApp
+        AdditionalESStorageinGiB: !Ref AdditionalESStorageinGiB
+        KeyPairName: !Ref KeyPairName
+        LicenseAgreement: !Ref LicenseAgreement
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        RegionsPerInstance: !Ref RegionsPerInstance
+        SubnetID: !Ref PrivateSubnet1AID
+  ESInstanceStack2:
+    Condition: Start2RedhatInstances
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ESCWAStack
+      - BootstrapStack
+    Properties:
+      TemplateURL: !Sub
+        - >-
+          https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/mf-es-redhat-template.yaml
+        - QSS3Region: !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        AvailabilityZones: !Join
+          - ','
+          - !Ref AvailabilityZones
+        DomainAdminPassword: !Ref DomainAdminPassword
+        DomainDNSName: !Ref DomainDNSName
+        DomainMemberSGID: !Ref DomainMemberSGID
+        DBMasterUserPassword: !Ref DBMasterUserPassword
+        EMailNotificationTopic: !If
+          - HaveOperatorEmail
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+        ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        ESCWLogGroup: !Ref ESCWLogGroup
+        ESInstanceName: ESServer2
+        ESInstanceType: !Ref ESInstanceType
+        ESLicenseFilename: !Ref ESLicenseFilename
+        ESS3BucketName: !Ref ESS3BucketName
+        InstallFSDemoApp: !Ref InstallFSDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
+        InstallSQLDemoApp: !Ref InstallSQLDemoApp
+        AdditionalESStorageinGiB: !Ref AdditionalESStorageinGiB
+        KeyPairName: !Ref KeyPairName
+        LicenseAgreement: !Ref LicenseAgreement
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        RegionsPerInstance: !Ref RegionsPerInstance
+        SubnetID: !Ref PrivateSubnet1AID
+  ESInstanceWinStack1:
+    Condition: OSWindows
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ESCWAStack
       - BootstrapStack
     Properties:
       TemplateURL: !Sub
@@ -1051,7 +1466,6 @@ Resources:
           - HaveOperatorEmail
           - !Ref EMailNotificationTopic
           - !Ref 'AWS::NoValue'
-        ESCCITCPListenerPort: !Ref ESCCITCPListenerPort
         ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
         ESCWLogGroup: !Ref ESCWLogGroup
         ESDatabaseEndpointAddress: !If
@@ -1062,27 +1476,24 @@ Resources:
         ESInstanceType: !Ref ESInstanceType
         ESLicenseFilename: !Ref ESLicenseFilename
         ESS3BucketName: !Ref ESS3BucketName
-        FileshareDataFolderUNC: !If
-          - CreateRemoteFileshareServerStack
-          - !GetAtt RemoteFileshareServerStack.Outputs.FileshareDataFolderUNC
-          - !Ref 'AWS::NoValue'
-        FSDemoApp3270Port: !Ref FSDemoApp3270Port
         InstallFSDemoApp: !Ref InstallFSDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
         InstallSQLDemoApp: !Ref InstallSQLDemoApp
         AdditionalESStorageinGiB: !Ref AdditionalESStorageinGiB
         KeyPairName: !Ref KeyPairName
         LicenseAgreement: !Ref LicenseAgreement
         MFDSServiceAccountName: !Ref MFDSServiceAccountName
         MFDSServiceAccountPassword: !Ref MFDSServiceAccountPassword
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         RegionsPerInstance: !Ref RegionsPerInstance
-        SQLDemoApp3270Port: !Ref SQLDemoApp3270Port
         SubnetID: !Ref PrivateSubnet1AID
-  ESInstanceStack2:
-    Condition: Start2Instances
+  ESInstanceWinStack2:
+    Condition: Start2WindowsInstances
     Type: 'AWS::CloudFormation::Stack'
     DependsOn:
+      - ESCWAStack
       - BootstrapStack
     Properties:
       TemplateURL: !Sub
@@ -1104,7 +1515,6 @@ Resources:
           - HaveOperatorEmail
           - !Ref EMailNotificationTopic
           - !Ref 'AWS::NoValue'
-        ESCCITCPListenerPort: !Ref ESCCITCPListenerPort
         ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
         ESCWLogGroup: !Ref ESCWLogGroup
         ESDatabaseEndpointAddress: !If
@@ -1115,22 +1525,18 @@ Resources:
         ESInstanceType: !Ref ESInstanceType
         ESLicenseFilename: !Ref ESLicenseFilename
         ESS3BucketName: !Ref ESS3BucketName
-        FileshareDataFolderUNC: !If
-          - CreateRemoteFileshareServerStack
-          - !GetAtt RemoteFileshareServerStack.Outputs.FileshareDataFolderUNC
-          - !Ref 'AWS::NoValue'
-        FSDemoApp3270Port: !Ref FSDemoApp3270Port
         InstallFSDemoApp: !Ref InstallFSDemoApp
+        InstallPACDemoApp: !Ref InstallPACDemoApp
         InstallSQLDemoApp: !Ref InstallSQLDemoApp
         AdditionalESStorageinGiB: !Ref AdditionalESStorageinGiB
         KeyPairName: !Ref KeyPairName
         LicenseAgreement: !Ref LicenseAgreement
         MFDSServiceAccountName: !Ref MFDSServiceAccountName
         MFDSServiceAccountPassword: !Ref MFDSServiceAccountPassword
+        PACDBMasterUserPassword: !Ref PACDBMasterUserPassword
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         RegionsPerInstance: !Ref RegionsPerInstance
-        SQLDemoApp3270Port: !Ref SQLDemoApp3270Port
         SubnetID: !Ref PrivateSubnet1AID
   ESDemoAppsPublicNetworkLoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
@@ -1161,11 +1567,11 @@ Resources:
     Condition: InstallingFSDemoApp
     Properties:
       HealthCheckIntervalSeconds: 30
-      HealthCheckPort: !Ref FSDemoApp3270Port
+      HealthCheckPort: "5555"
       HealthCheckProtocol: TCP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 3
-      Port: !Ref FSDemoApp3270Port
+      Port: 5555
       Protocol: TCP
       Tags:
         - Key: Name
@@ -1179,12 +1585,25 @@ Resources:
                   - !Sub '${AWS::StackName}-'
                   - !Sub '${ESResourceNamePrefix}-'
       Targets:
-        - Id: !GetAtt ESInstanceStack1.Outputs.ESInstanceID
-          Port: !Ref FSDemoApp3270Port
         - !If
-          - Start2Instances
+          - OSRedhat
+          - Id: !GetAtt ESInstanceStack1.Outputs.ESInstanceID
+            Port: 5555
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2RedhatInstances
           - Id: !GetAtt ESInstanceStack2.Outputs.ESInstanceID
-            Port: !Ref FSDemoApp3270Port
+            Port: 5555
+          - !Ref 'AWS::NoValue'
+        - !If
+          - OSWindows
+          - Id: !GetAtt ESInstanceWinStack1.Outputs.ESInstanceID
+            Port: 5555
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2WindowsInstances
+          - Id: !GetAtt ESInstanceWinStack2.Outputs.ESInstanceID
+            Port: 5555
           - !Ref 'AWS::NoValue'
       TargetType: instance
       UnhealthyThresholdCount: 3
@@ -1197,18 +1616,18 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref FSDemoApp3270AppsLoadBalancerTargetGroup
       LoadBalancerArn: !Ref ESDemoAppsPublicNetworkLoadBalancer
-      Port: !Ref FSDemoApp3270Port
+      Port: 5555
       Protocol: TCP
   SQLDemoApp3270AppsLoadBalancerTargetGroup:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Condition: InstallingSQLDemoApp
     Properties:
       HealthCheckIntervalSeconds: 30
-      HealthCheckPort: !Ref SQLDemoApp3270Port
+      HealthCheckPort: "5556"
       HealthCheckProtocol: TCP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 3
-      Port: !Ref SQLDemoApp3270Port
+      Port: 5556
       Protocol: TCP
       Tags:
         - Key: Name
@@ -1222,12 +1641,25 @@ Resources:
                   - !Sub '${AWS::StackName}-'
                   - !Sub '${ESResourceNamePrefix}-'
       Targets:
-        - Id: !GetAtt ESInstanceStack1.Outputs.ESInstanceID
-          Port: !Ref SQLDemoApp3270Port
         - !If
-          - Start2Instances
+          - OSRedhat
+          - Id: !GetAtt ESInstanceStack1.Outputs.ESInstanceID
+            Port: 5556
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2RedhatInstances
           - Id: !GetAtt ESInstanceStack2.Outputs.ESInstanceID
-            Port: !Ref SQLDemoApp3270Port
+            Port: 5556
+          - !Ref 'AWS::NoValue'
+        - !If
+          - OSWindows
+          - Id: !GetAtt ESInstanceWinStack1.Outputs.ESInstanceID
+            Port: 5556
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2WindowsInstances
+          - Id: !GetAtt ESInstanceWinStack2.Outputs.ESInstanceID
+            Port: 5556
           - !Ref 'AWS::NoValue'
       TargetType: instance
       UnhealthyThresholdCount: 3
@@ -1240,18 +1672,66 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref SQLDemoApp3270AppsLoadBalancerTargetGroup
       LoadBalancerArn: !Ref ESDemoAppsPublicNetworkLoadBalancer
-      Port: !Ref SQLDemoApp3270Port
+      Port: 5556
+      Protocol: TCP
+  PACDemoApp3270AppsLoadBalancerTargetGroup:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Condition: InstallingPACDemoApp
+    Properties:
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPort: "5557"
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 3
+      Port: 5557
+      Protocol: TCP
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - '${StackNamePrefix}SQLDemoApp3270'
+            - StackNamePrefix: !If
+                - NamePrefixIsUndefined
+                - ''
+                - !If
+                  - NamePrefixIsAWSStackname
+                  - !Sub '${AWS::StackName}-'
+                  - !Sub '${ESResourceNamePrefix}-'
+      Targets:
+        - !If
+          - OSRedhat
+          - Id: !GetAtt ESInstanceStack1.Outputs.ESInstanceID
+            Port: 5557
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2RedhatInstances
+          - Id: !GetAtt ESInstanceStack2.Outputs.ESInstanceID
+            Port: 5557
+          - !Ref 'AWS::NoValue'
+        - !If
+          - OSWindows
+          - Id: !GetAtt ESInstanceWinStack1.Outputs.ESInstanceID
+            Port: 5557
+          - !Ref 'AWS::NoValue'
+        - !If
+          - Start2WindowsInstances
+          - Id: !GetAtt ESInstanceWinStack2.Outputs.ESInstanceID
+            Port: 5557
+          - !Ref 'AWS::NoValue'
+      TargetType: instance
+      UnhealthyThresholdCount: 3
+      VpcId: !Ref VPCID
+  PACDemoApp3270AppsLoadBalancerListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Condition: InstallingPACDemoApp
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref PACDemoApp3270AppsLoadBalancerTargetGroup
+      LoadBalancerArn: !Ref ESDemoAppsPublicNetworkLoadBalancer
+      Port: 5557
       Protocol: TCP
 Outputs:
   ESDemoAppsPublicNetworkLoadBalancer:
     Condition: InstallingAtLeastOneDemoApp
     Description: The DNS name for the load balancer.
     Value: !GetAtt ESDemoAppsPublicNetworkLoadBalancer.DNSName
-  FSDemoApp3270Port:
-    Condition: InstallingFSDemoApp
-    Description: The Fileshare Bank Demo TN3270 port number
-    Value: !Ref FSDemoApp3270Port
-  SQLDemoApp3270Port:
-    Condition: InstallingSQLDemoApp
-    Description: The SQLServer Bank Demo TN3270 port number
-    Value: !Ref SQLDemoApp3270Port

--- a/templates/mf-escwa-template.yaml
+++ b/templates/mf-escwa-template.yaml
@@ -1,0 +1,927 @@
+# © Copyright 2018 Micro Focus or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  "This template deploys a single Micro Focus Enterprise Server instance as
+  defined in the Micro Focus Enterprise Server Reference Architecture.
+  **WARNING** This template creates EC2 instances and related resources. You
+  will be billed for the AWS resources used if you create a stack from this
+  template. License: Apache 2.0 (Please do not remove) Sept,05,2018. Micro Focus
+  Enterprise Server is licensed separately, please review the terms and
+  conditions here (https://www.microfocus.com/about/legal/) for further details.
+  (qs-1qeg3mku7)"
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Software License Agreement
+        Parameters:
+          - LicenseAgreement
+          - ESLicenseFilename
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - AvailabilityZones
+          - SubnetID
+      - Label:
+          default: Microsoft Active Directory Configuration
+        Parameters:
+          - DomainDNSName
+          - DomainNetBIOSName
+          - DomainMemberSGID
+          - DomainAdminPassword
+      - Label:
+          default: Enterprise Server Configuration
+        Parameters:
+          - ESCWAInstanceType
+          - KeyPairName
+          - MFDSServiceAccountName
+          - MFDSServiceAccountPassword
+          - ESClientAccessSGID
+          - ESS3BucketName
+          - EMailNotificationTopic
+          - ESCWLogGroup
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      AvailabilityZones:
+        default: Availability Zones
+      DomainAdminPassword:
+        default: Domain Admin account password
+      DomainDNSName:
+        default: Domain DNS name
+      DomainNetBIOSName:
+        default: Domain NetBIOS name
+      DomainMemberSGID:
+        default: Domain member Security Group ID
+      EMailNotificationTopic:
+        default: EMail Notification Topic
+      ESClientAccessSGID:
+        default: Enterprise Server Application (Client) Access Security Group ID
+      ESCWLogGroup:
+        default: Amazon CloudWatch Log Group
+      ESCWAInstanceType:
+        default: Enterprise Server instance type
+      ESLicenseFilename:
+        default: Enterprise Server license filename
+      ESS3BucketName:
+        default: Enterprise Server S3 bucket name
+      KeyPairName:
+        default: Key pair name
+      LicenseAgreement:
+        default: License agreement
+      MFDSServiceAccountName:
+        default: Micro Focus Directory Server service domain account name
+      MFDSServiceAccountPassword:
+        default: Micro Focus Directory Server service account password
+      SubnetID:
+        default: Subnet ID
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+Parameters:
+  AvailabilityZones:
+    Description: >-
+      List of Availability Zones to use for the subnets in the VPC. Only two
+      Availability Zones are used for this deployment, and the logical order
+      of your selections is preserved.
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  DomainAdminPassword:
+    AllowedPattern: >-
+      (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: >-
+      The password for the domain Admin account. Must be at least 8 characters
+      containing letters, numbers, and symbols.
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: true
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: >-
+      The fully qualified domain name (FQDN), e.g., example.com. Must be 2-255
+      characters.
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainMemberSGID:
+    Description: >-
+      The ID of the Domain Member Security Group (e.g., sg-7f16e910).
+    Type: 'AWS::EC2::SecurityGroup::Id'
+  DomainNetBIOSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+'
+    Default: example
+    Description: >-
+      The NetBIOS name of the domain (up to 15 characters) for users of
+      earlier versions of Microsoft Windows, e.g., example.
+    MaxLength: '15'
+    Type: String
+  EMailNotificationTopic:
+    Type: String
+    Default: ''
+  ESClientAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: >-
+      Security Group ID for application ingress into the Enterpriser Server
+      instance (e.g., sg-1234abcd).
+  ESCWLogGroup:
+    Type: String
+    Description: The logical ID of the Amazon CloudWatch Logs Log Group
+  ESCWAInstanceType:
+    AllowedValues:
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+    Description: The type of Enterprise Server instance.
+    Default: c5.large
+    Type: String
+  ESLicenseFilename:
+    Description: >-
+      Place the license file obtained from Micro Focus in the S3 bucket folder:
+      s3://<Enterprise Server S3 bucket name>/license/
+    Type: String
+  ESS3BucketName:
+    AllowedPattern: '^[a-z0-9][a-z0-9-.]*$'
+    Description: >-
+      The name of the existing S3 bucket used to store/retrieve objects specific
+      to this stack. A system integrator extending this Quick Start should use
+      this bucket to store or retrieve items needed. This string can include
+      numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
+      start or end with a hyphen (-).
+    Type: String
+  KeyPairName:
+    Description: >-
+      The name of an existing EC2 key pair. All instances will launch with this key pair.
+    Type: 'AWS::EC2::KeyPair::KeyName'
+  LicenseAgreement:
+    Description: >-
+      I have read and agree to the license terms for Micro Focus Enterprise
+      Server
+      (https://www.microfocus.com/documentation/enterprise-developer/ed-latest/ES-WIN/GUID-0562B3C9-2271-4CE8-AF64-93DE4940077F.html).
+    Type: String
+    Default: '-'
+    AllowedValues:
+      - I agree
+      - '-'
+    ConstraintDescription: must answer 'I agree'.
+  MFDSServiceAccountName:
+    Type: String
+    AllowedPattern: '[a-zA-Z0-9]*'
+    Default: 'MFDSServiceAccount'
+    Description: >-
+      The existing domain account name under which the service will run. If left as
+      default, a domain account 'MFDSServiceAccount' is created. The name must be
+      5-25 characters.
+    MaxLength: '25'
+    MinLength: '5'
+  MFDSServiceAccountPassword:
+    Type: String
+    AllowedPattern: >-
+      (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: >-
+      Enter a password for MFDSServiceAccount. Must be at least 8 characters
+      containing letters, numbers, and symbols.
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: true
+  SubnetID:
+    Description: 'The ID of a private subnet in an Availability Zone (e.g., subnet-a0246dcd).'
+    Type: 'AWS::EC2::Subnet::Id'
+  QSS3BucketName:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can
+      include numbers, lowercase letters, uppercase letters, and hyphens (-). It
+      cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: '^[0-9a-zA-Z-/]*$'
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase
+      letters, hyphens (-), and forward slash (/).
+    Default: quickstart-microfocus-amc-es/
+    Description: >-
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can
+      include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+Rules:
+  KeyPairsNotEmpty:
+    Assertions:
+      - Assert: !Not
+          - 'Fn::EachMemberEquals':
+              - 'Fn::RefAll': 'AWS::EC2::KeyPair::KeyName'
+              - ''
+        AssertDescription: All key pair parameters must not be empty.
+  LicenseAgreementRule:
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+            - - I agree
+            - !Ref LicenseAgreement
+        AssertDescription: User must agree to the terms of the license agreement.
+Mappings:
+  AWSAMIRegionMap:
+    AMI:
+      MFES40AMI: ES_50_PU05
+    ap-northeast-1:
+      MFES40AMI: ami-0dff3f5a16ecacfe5
+    ap-northeast-2:
+      MFES40AMI: ami-0248d8806a80ec1be
+    ap-south-1:
+      MFES40AMI: ami-07c28d590f4c42580
+    ap-southeast-1:
+      MFES40AMI: ami-0a8d6fe92bdb3a94f
+    ap-southeast-2:
+      MFES40AMI:  ami-05d45ddc80bfd6446
+    ca-central-1:
+      MFES40AMI: ami-0f0adf2454aa54382
+    eu-central-1:
+      MFES40AMI: ami-00664de4c7c03a310
+    eu-north-1:
+      MFES40AMI: ami-09a1a20c436e7806e
+    eu-west-1:
+      MFES40AMI: ami-03e0b7531700529c5
+    eu-west-2:
+      MFES40AMI: ami-0ed05eb873c2da4ef
+    eu-west-3:
+      MFES40AMI: ami-0dd39cc30ea3574b7
+    sa-east-1:
+      MFES40AMI: ami-082e4e947dbbf35b1
+    us-east-1:
+      MFES40AMI: ami-0e6255dfab3d7497c
+    us-east-2:
+      MFES40AMI: ami-048a75e3c74fdfa5f
+    us-west-1:
+      MFES40AMI: ami-074e117de783cab22
+    us-west-2:
+      MFES40AMI: ami-09dc8cff0a367fa32
+Conditions:
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
+  HaveESlicenseFilename: !Not
+    - !Equals
+      - !Ref ESLicenseFilename
+      - ''
+  HaveEMailNotificationTopic: !Not
+    - !Equals
+      - !Ref EMailNotificationTopic
+      - ''
+Resources:
+  ESCWAInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:GetObject'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+            Version: 2012-10-17
+          PolicyName: aws-quick-start-s3-policy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:*'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}/*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+              - Action:
+                  - 'ds:Describe*'
+                Effect: Allow
+                Resource: '*'
+          PolicyName: ESCWAInstancePolicy
+  ESCWAInstanceRoleProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref ESCWAInstanceRole
+  LambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  ESCWAInstance:
+    Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT25M
+    Metadata:
+      'AWS::CloudFormation::Authentication':
+        S3AccessCreds:
+          type: S3
+          roleName: !Ref ESCWAInstanceRole
+          buckets:
+            - !Ref QSS3BucketName
+            - !Ref ESS3BucketName
+      'AWS::CloudFormation::Init':
+        configSets:
+          config:
+            - 010-InstallTools
+            - 020-ConfigureCWLogs
+            - 030-InitPowerShell
+            - 040-ConfigureEnterpriseServer
+            - !If
+              - HaveESlicenseFilename
+              - 050-ApplyESLicenseFile
+              - 000-NoOperation
+            - 060-RenameAndJoinDomain
+            - 070-Setup-ESCWA-Environment
+            - 090-Finalize
+        000-NoOperation:
+          commands:
+            a-no-operation:
+              command: echo "No-Operation" > nul
+              waitAfterCompletion: '0'
+        010-InstallTools:
+          files:
+            'c:\cfn\assets\AWSCLI64PY3.msi':
+              source: 'https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi'
+            'c:\cfn\assets\GoogleChromeStandaloneEnterprise64.msi':
+              source: >-
+                https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi
+          commands:
+            a-install-aws-cli:
+              command: 'start /wait c:\cfn\assets\AWSCLI64PY3.msi /quiet /passive /qn'
+              waitAfterCompletion: '0'
+            b-install-chrome:
+              command: >-
+                start /wait c:\cfn\assets\GoogleChromeStandaloneEnterprise64.msi
+                /quiet /passive
+              waitAfterCompletion: '0'
+        020-ConfigureCWLogs:
+          files:
+            'C:\Program Files\Amazon\SSM\Plugins\awsCloudWatch\AWS.EC2.Windows.CloudWatch.json':
+              content: !Sub |
+                {
+                  "IsEnabled": true,
+                  "EngineConfiguration": {
+                    "PollInterval": "00:00:05",
+                    "Components": [
+                      {
+                        "Id": "ApplicationEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "LogName": "Application",
+                          "Levels": "7"
+                        }
+                      },
+                      {
+                        "Id": "SystemEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "LogName": "System",
+                          "Levels": "7"
+                        }
+                      },
+                      {
+                        "Id": "SecurityEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "LogName": "Security",
+                          "Levels": "7"
+                        }
+                      },
+                      {
+                        "Id": "EC2ConfigLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CustomLog.CustomLogInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "LogDirectoryPath": "C:\\Program Files\\Amazon\\Ec2ConfigService\\Logs",
+                          "TimestampFormat": "yyyy-MM-ddTHH:mm:ss.fffZ:",
+                          "Encoding": "ASCII",
+                          "Filter": "EC2ConfigLog.txt",
+                          "CultureName": "en-US",
+                          "TimeZoneKind": "UTC"
+                        }
+                      },
+                      {
+                        "Id": "CfnInitLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CustomLog.CustomLogInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "LogDirectoryPath": "C:\\cfn\\log",
+                          "TimestampFormat": "yyyy-MM-dd HH:mm:ss,fff",
+                          "Encoding": "ASCII",
+                          "Filter": "cfn-init.log",
+                          "CultureName": "en-US",
+                          "TimeZoneKind": "Local"
+                        }
+                      },
+                      {
+                        "Id": "MemoryPerformanceCounter",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.PerformanceCounterComponent.PerformanceCounterInputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "CategoryName": "Memory",
+                          "CounterName": "Available MBytes",
+                          "InstanceName": "",
+                          "MetricName": "Memory",
+                          "Unit": "Megabytes",
+                          "DimensionName": "",
+                          "DimensionValue": ""
+                        }
+                      },
+                      {
+                        "Id": "CloudWatchApplicationEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "LogGroup": "${ESCWLogGroup}",
+                          "LogStream": "ES/{instance_id}/ApplicationEventLog"
+                        }
+                      },
+                      {
+                        "Id": "CloudWatchSystemEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "LogGroup": "${ESCWLogGroup}",
+                          "LogStream": "ES/{instance_id}/SystemEventLog"
+                        }
+                      },
+                      {
+                        "Id": "CloudWatchSecurityEventLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "LogGroup": "${ESCWLogGroup}",
+                          "LogStream": "ES/{instance_id}/SecurityEventLog"
+                        }
+                      },
+                      {
+                        "Id": "CloudWatchEC2ConfigLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "LogGroup": "${ESCWLogGroup}",
+                          "LogStream": "ES/{instance_id}/EC2ConfigLog"
+                        }
+                      },
+                      {
+                        "Id": "CloudWatchCfnInitLog",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "LogGroup": "${ESCWLogGroup}",
+                          "LogStream": "ES/{instance_id}/CfnInitLog"
+                        }
+                      },
+                      {
+                        "Id": "CloudWatch",
+                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatch.CloudWatchOutputComponent,AWS.EC2.Windows.CloudWatch",
+                        "Parameters": {
+                          "AccessKey": "",
+                          "SecretKey": "",
+                          "Region": "${AWS::Region}",
+                          "NameSpace": "Windows/Default"
+                        }
+                      }
+                    ],
+                    "Flows": {
+                      "Flows": [
+                        "ApplicationEventLog,CloudWatchApplicationEventLog",
+                        "SystemEventLog,CloudWatchSystemEventLog",
+                        "SecurityEventLog,CloudWatchSecurityEventLog",
+                        "EC2ConfigLog,CloudWatchEC2ConfigLog",
+                        "CfnInitLog,CloudWatchCfnInitLog",
+                        "MemoryPerformanceCounter,CloudWatch"
+                      ]
+                    }
+                  }
+                }
+          commands:
+            a-restartSSM:
+              command: powershell.exe -Command Restart-Service AmazonSSMAgent
+              ignoreErrors: true
+              waitAfterCompletion: 0
+        030-InitPowerShell:
+          files:
+            'C:\cfn\scripts\Unzip-Archive.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-microsoft-utilities/scripts/Unzip-Archive.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\modules\AWSQuickStart.zip':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-microsoft-utilities/modules/AWSQuickStart.zip
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\cfn-hup.conf':
+              content: !Sub |
+                [main]
+                stack=${AWS::StackName}
+                region=${AWS::Region}
+            'c:\cfn\hooks.d\cfn-auto-reloader.conf':
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.ESCWAInstance.Metadata.AWS::CloudFormation::Init
+                action=cfn-init.exe -v -c config -s ${AWS::StackId} --resource ESCWAInstance --region ${AWS::Region}
+            'c:\cfn\scripts\AddTo-SystemPath.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/AddTo-SystemPath.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Schedule-AD-PowershellTask.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Schedule-AD-PowershellTask.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\scripts\Join-Domain.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-microsoft-utilities/scripts/Join-Domain.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'C:\cfn\scripts\Rename-Computer.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-microsoft-utilities/scripts/Rename-Computer.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          services:
+            windows:
+              cfn-hup:
+                enabled: 'true'
+                ensureRunning: 'true'
+                files:
+                  - 'c:\cfn\cfn-hup.conf'
+                  - 'c:\cfn\hooks.d\cfn-auto-reloader.conf'
+          commands:
+            a-set-execution-policy:
+              command:
+                powershell.exe
+                  -Command "Set-ExecutionPolicy RemoteSigned"
+                  -Force
+              waitAfterCompletion: '0'
+            b-unpack-quickstart-module:
+              command:
+                powershell.exe
+                  -File C:\cfn\scripts\Unzip-Archive.ps1
+                    -Source C:\cfn\modules\AWSQuickStart.zip
+                    -Destination C:\Windows\system32\WindowsPowerShell\v1.0\Modules\
+              waitAfterCompletion: '0'
+            c-init-quickstart-module:
+              command: !Sub
+                powershell.exe
+                  -Command New-AWSQuickStartResourceSignal
+                    -Stack ${AWS::StackName}
+                    -Resource ESCWAInstance
+                    -Region ${AWS::Region}
+              waitAfterCompletion: '0'
+        040-ConfigureEnterpriseServer:
+          files:
+            'c:\cfn\scripts\StartESRegion.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/StartESRegion.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          commands:
+            a-update-system-path:
+              command:
+                powershell.exe
+                  -File c:\cfn\scripts\AddTo-SystemPath.ps1
+                    -PathToAdd "C:\Program Files (x86)\Micro Focus\Enterprise Server\bin"
+              waitAfterCompletion: '0'
+            b-configure-windows-firewall-es-admin-portal-rule:
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'Micro Focus Enterprise Server Admin Portal'
+                    -LocalPort 86
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+            c-configure-windows-firewall-es-admin-portal-rule:
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'Micro Focus Enterprise Server Admin Portal'
+                    -LocalPort 86
+                    -Protocol udp
+              waitAfterCompletion: '0'
+            d-configure-windows-firewall-fs-demoapp-tn3270-portal-rule:
+              command:
+                powershell.exe
+                  -Command New-NetFirewallRule
+                    -DisplayName 'Enterprise Server Common Web Administration Portal'
+                    -LocalPort 10004
+                    -Protocol tcp
+              waitAfterCompletion: '0'
+        050-ApplyESLicenseFile:
+          files:
+            'c:\esdir\Enterprise-Server.mflic':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/license/${ESLicenseFilename}
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          commands:
+            a-install-license:
+              cwd: 'C:\Program Files (x86)\Common Files\SafeNet Sentinel\Sentinel RMS License Manager\WinNT\'
+              command:
+                start /wait
+                  cesadmintool
+                    -term install
+                    -f c:\esdir\Enterprise-Server.mflic
+              waitAfterCompletion: '0'
+        060-RenameAndJoinDomain:
+          commands:
+            a-rename-computer:
+              command:
+                powershell.exe
+                  -File C:\cfn\scripts\Rename-Computer.ps1
+                    -NewName ESCWAInstance
+                    -Restart
+              waitAfterCompletion: forever
+            b-join-domain-and-restart:
+              command: !Sub
+                powershell.exe
+                  -File C:\cfn\scripts\Join-Domain.ps1
+                    -DomainName ${DomainDNSName}
+                    -UserName ${DomainNetBIOSName}\Admin
+                    -Password ${DomainAdminPassword}
+              waitAfterCompletion: forever
+            # Add 'Domain Users' to local RDP Group to they can RDP into this instance
+            # Install A/D Management Tools
+            c-add-domain-users-rdp-users-group:
+              command: !Sub
+                powershell
+                  -Command
+                    "&{
+                        try {
+                          $ErrorActionPreference = 'Stop';
+                          $GroupObj = [ADSI]'WinNT://localhost/Remote Desktop Users';
+                          $GroupObj.Add('WinNT://${DomainNetBIOSName}/Domain Users');
+                          Install-WindowsFeature
+                            -Name GPMC,RSAT-AD-PowerShell,RSAT-AD-AdminCenter,RSAT-ADDS-Tools,RSAT-DNS-Server;
+                        } catch {
+                          $_ | Write-AWSQuickStartException;
+                        }
+                      }"
+              waitAfterCompletion: '0'
+        070-Setup-ESCWA-Environment:
+          files:
+            'c:\cfn\scripts\Configure-ESCWA.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Configure-ESCWA.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Add-Other-MFDS.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Add-Other-MFDS.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Configure-PAC.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Configure-PAC.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+            'c:\cfn\scripts\Configure-UserLogonPrivileges.ps1':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Configure-UserLogonPrivileges.ps1
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              authentication: S3AccessCreds
+          commands:
+            a-grant-mfds-account-logon-as-a-service:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-UserLogonPrivileges.ps1
+                    -Username "${DomainNetBIOSName}\${MFDSServiceAccountName}"
+                    -PrivilegeName "SeServiceLogonRight"
+                    -Status Grant
+              waitAfterCompletion: '0'
+            b-grant-mfds-account-logon-as-batch-job:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-UserLogonPrivileges.ps1
+                    -Username "${DomainNetBIOSName}\${MFDSServiceAccountName}"
+                    -PrivilegeName "SeBatchLogonRight"
+                    -Status Grant
+              waitAfterCompletion: '0'
+            c-Configure-ESCWA:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-ESCWA.ps1
+                  -DomainNetBIOSName ${DomainNetBIOSName}
+                  -ServiceUser ${MFDSServiceAccountName}
+                  -ServicePassword ${MFDSServiceAccountPassword}
+              waitAfterCompletion: '0'
+            d-add-other-MFDS:
+              command: !Sub
+                powershell.exe
+                  -File c:\cfn\scripts\Add-Other-MFDS.ps1
+                  -DomainNetBIOSName ${DomainNetBIOSName}
+                  -ServiceUser ${MFDSServiceAccountName}
+                  -ServicePassword ${MFDSServiceAccountPassword}
+              waitAfterCompletion: '0'
+            e-Configure-PAC:
+              command:
+                powershell.exe
+                  -File c:\cfn\scripts\Configure-PAC.ps1
+              waitAfterCompletion: '0'
+        090-Finalize:
+          commands:
+            a-finalize-init:
+              command:
+                powershell.exe
+                  -Command Write-AWSQuickStartStatus
+              waitAfterCompletion: '0'
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
+      SubnetId: !Ref SubnetID
+      SecurityGroupIds:
+        - !Ref DomainMemberSGID
+        - !Ref ESClientAccessSGID
+      IamInstanceProfile: !Ref ESCWAInstanceRoleProfile
+      KeyName: !Ref KeyPairName
+      InstanceType: !Ref ESCWAInstanceType
+      ImageId: !FindInMap
+        - AWSAMIRegionMap
+        - !Ref 'AWS::Region'
+        - MFES40AMI
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-ESCWA'
+      UserData: !Base64
+        'Fn::Sub':
+          - |
+            <script>
+              rem Uninstall Amazon SSM Agent and AWS CLI to allow updating
+              wmic product where "description='Amazon SSM Agent' " uninstall
+              wmic product where "description='aws-cfn-bootstrap' " uninstall
+
+              rem Install latest AWS CloudFormation Helper Scripts
+              start /wait c:\Windows\system32\msiexec /passive /qn /i https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-win64-latest.msi
+
+              rem Download and run the latest Amazon SSM Agent setup
+              powershell.exe -Command "iwr https://${QSS3Region}.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/windows_amd64/AmazonSSMAgentSetup.exe -UseBasicParsing -OutFile C:\AmazonSSMAgentSetup.exe"
+              start /wait C:\AmazonSSMAgentSetup.exe /install /quiet
+
+              rem Run cfn-init helper to process AWS::CloudFormation::Init directives
+              cfn-init.exe -v -c config -s ${AWS::StackName} --resource ESCWAInstance --region ${AWS::Region}
+            </script>
+          - QSS3Region: !If
+              - GovCloudCondition
+              - s3-us-gov-west-1
+              - s3
+  ESCWAInstanceRecoveryAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: !Sub |
+        "${AWS::StackName} Stack instance auto-recovery alarm/trigger."
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed_System
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 5
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+        - !Sub 'arn:aws:automate:${AWS::Region}:ec2:recover'
+        - !If
+          - HaveEMailNotificationTopic
+          - !Ref EMailNotificationTopic
+          - !Ref 'AWS::NoValue'
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref ESCWAInstance
+Outputs:
+  ESCWAInstanceID:
+    Description: The Enterprise Server EC2 Instance ID
+    Value: !Ref ESCWAInstance
+  ESCWAInstanceAZ:
+    Description: >-
+      The Availability Zone where the deployed Enterprise Server instance is
+      launched.
+    Value: !GetAtt ESCWAInstance.AvailabilityZone
+  ESCWAInstancePrivateDnsName:
+    Description: The private DNS name of the deployed Enterprise Server instance
+    Value: !GetAtt ESCWAInstance.PrivateDnsName
+  ESCWAInstancePrivateIp:
+    Description: The private IP address of the deployed Enterprise Server instance
+    Value: !GetAtt ESCWAInstance.PrivateIp

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -1,0 +1,715 @@
+# © Copyright 2018 Micro Focus or one of its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  "Deploys a Micro Focus Enterprise Server Fileshare Server. **WARNING** This
+  template creates EC2 instances and related resources. You will be billed for
+  the AWS resources used if you create a stack from this template. Micro Focus
+  Enterprise Server is licensed separately, please review the terms and
+  conditions here (https://www.microfocus.com/about/legal/) for further details.
+  (qs-1p440hhtu)"
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Software License Agreement
+        Parameters:
+          - LicenseAgreement
+          - ESLicenseFilename
+      - Label:
+          default: Network Configuration
+        Parameters:
+          - VPCID
+          - PrivateSubnet1AID
+          - AvailabilityZones
+      - Label:
+          default: Microsoft Active Directory Configuration
+        Parameters:
+          - DomainDNSName
+          - DomainMemberSGID
+          - DomainAdminPassword
+      - Label:
+          default: Enterprise Server Fileshare Configuration
+        Parameters:
+          - FSInstanceType
+          - FSStorageInGiB
+          - FSVIEWUserPassword
+          - FSServerName
+          - KeyPairName
+          - FSClientAccessSGID
+          - ESCWLogGroup
+          - ESS3BucketName
+          - NotificationARN
+          - ESResourceNamePrefix
+      - Label:
+          default: Enterprise Server Demo Apps Configuration
+        Parameters:
+          - InstallDemoApps
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      AvailabilityZones:
+        default: Availability Zones
+      DomainAdminPassword:
+        default: Domain Admin account password
+      DomainDNSName:
+        default: Domain DNS name
+      DomainMemberSGID:
+        default: Domain member Security Group ID
+      ESCWLogGroup:
+        default: Amazon CloudWatch LogGroup
+      ESLicenseFilename:
+        default: Enterprise Server license filename
+      ESResourceNamePrefix:
+        default: Resource 'Name' prefix
+      ESS3BucketName:
+        default: Enterprise Server S3 bucket name
+      FSInstanceType:
+        default: Enterprise Server Fileshare instance type
+      FSClientAccessSGID:
+        default: ES Client Access Security Group ID
+      FSServerName:
+        default: Fileshare Server Name
+      FSStorageInGiB:
+        default: Fileshare allocated storage size
+      FSVIEWUserPassword:
+        default: FSVIEW user password
+      InstallDemoApps:
+        default: Install Demo Apps
+      KeyPairName:
+        default: Key pair name
+      LicenseAgreement:
+        default: License agreement
+      NotificationARN:
+        default: Notification ARN
+      PrivateSubnet1AID:
+        default: Private Subnet 1A ID
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
+      VPCID:
+        default: VPC ID
+Parameters:
+  AvailabilityZones:
+    Description: >-
+      List of Availability Zones to use for the subnets in the VPC. Only two
+      Availability Zones are used for this deployment, and the logical order
+      of your selections is preserved.
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+  BastionAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: >-
+      The security group ID for access from the Remote Desktop Gateway.
+  DomainAdminPassword:
+    AllowedPattern: >-
+      (?=^.{6,255}$)((?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*
+    Description: >-
+      The password for the domain Admin account. Must be at least 8 characters
+      containing letters, numbers, and symbols.
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: true
+    Type: String
+  DomainDNSName:
+    AllowedPattern: '[a-zA-Z0-9\-]+\..+'
+    Default: example.com
+    Description: >-
+      The fully qualified domain name (FQDN), e.g., example.com. Must be 2-255
+      characters.
+    MaxLength: '255'
+    MinLength: '2'
+    Type: String
+  DomainMemberSGID:
+    Description: >-
+      The ID of the Domain Member Security Group (e.g., sg-7f16e910).
+    Type: 'AWS::EC2::SecurityGroup::Id'
+  ESCWLogGroup:
+    Type: String
+    Description: The logical ID of the Amazon CloudWatch Logs Log Group
+  ESLicenseFilename:
+    Description: >-
+      Place the license file obtained from Micro Focus in the S3 bucket folder:
+      s3://<Enterprise Server S3 bucket name>/license/
+    Type: String
+  ESResourceNamePrefix:
+    Default: 'AWS::StackName'
+    Description: >-
+      Used to prefix resource 'Name' tags. Leave empty for no prefix.
+      Otherwise, use 'AWS::StackName' or a value such as the parent stack's
+      name.
+    Type: String
+  ESS3BucketName:
+    AllowedPattern: '^[a-z0-9][a-z0-9-.]*$'
+    Description: >-
+      The name of the existing S3 bucket used to store/retrieve objects specific
+      to this stack. A system integrator extending this Quick Start should use
+      this bucket to store or retrieve items needed. This string can include
+      numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
+      start or end with a hyphen (-).
+    Type: String
+  FSClientAccessSGID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: >-
+      Security Group ID for application ingress into the Enterpriser Server Fileshare
+      instance (e.g., sg-1234abcd).
+  FSInstanceType:
+    AllowedValues:
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+    Description: The type of Enterprise Server Fileshare instance.
+    Default: c5.large
+    Type: String
+  FSServerName:
+    Description: The name to assign to the Fileshare instance Windows Hostname
+    Default: FSServer
+    Type: String
+  FSStorageInGiB:
+    Default: 250
+    Description: Enter 1-16384 GiB.
+    MaxValue: 16384
+    MinValue: 1
+    Type: Number
+  FSVIEWUserPassword:
+    AllowedPattern: >-
+      ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,32}$
+    Description: >-
+      The password for the FSVIEW user. Must contain 8 to 32 characters,
+      at least one uppercase letter, one lowercase letter, one number and
+      one special character.
+    ConstraintDescription: >-
+      Must contain 8 to 32 characters, at least one uppercase letter, one
+      lowercase letter, one number and one special character.
+    MaxLength: '32'
+    MinLength: '8'
+    NoEcho: true
+    Type: String
+  InstallDemoApps:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: true
+    Description: Choose 'false' if you want to skip installation of the Enterprise Server demo apps.
+  KeyPairName:
+    Description: >-
+      The name of an existing EC2 key pair. All instances will launch with this key pair.
+    Type: 'AWS::EC2::KeyPair::KeyName'
+  LicenseAgreement:
+    AllowedValues:
+      - I agree
+      - '-'
+    ConstraintDescription: Must answer 'I agree'.
+    Default: '-'
+    Description: >-
+      I have read and agree to the license terms for Micro Focus Enterprise
+      Server
+      (https://www.microfocus.com/documentation/enterprise-developer/ed-latest/ES-WIN/GUID-0562B3C9-2271-4CE8-AF64-93DE4940077F.html).
+    Type: String
+  NotificationARN:
+    Description: >-
+      (optional) An existing Amazon SNS topic where notifications about are
+      sent, e.g., email notifications.
+    Type: String
+    Default: ''
+  PrivateSubnet1AID:
+    Description: >-
+      The ID of private subnet 1A in Availability Zone 1 (e.g.,
+      subnet-a0246dcd).
+    Type: 'AWS::EC2::Subnet::Id'
+  QSS3BucketName:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can
+      include numbers, lowercase letters, uppercase letters, and hyphens (-). It
+      cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: '^[0-9a-zA-Z-/]*$'
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase
+      letters, hyphens (-), and forward slash (/).
+    Default: quickstart-microfocus-amc-es/
+    Description: >-
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can
+      include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+  VPCID:
+    Description: ID of your existing VPC for deployment.
+    Type: 'AWS::EC2::VPC::Id'
+Rules:
+  KeyPairsNotEmpty:
+    Assertions:
+      - Assert: !Not
+          - 'Fn::EachMemberEquals':
+              - 'Fn::RefAll': 'AWS::EC2::KeyPair::KeyName'
+              - ''
+        AssertDescription: All key pair parameters must not be empty.
+  LicenseAgreementRule:
+    Assertions:
+      - Assert:
+          'Fn::Contains':
+            - - I agree
+            - !Ref LicenseAgreement
+        AssertDescription: User must agree to the terms of the license agreement.
+  SubnetsInVPC:
+    Assertions:
+      - Assert:
+          'Fn::EachMemberIn':
+            - 'Fn::ValueOfAll':
+                - 'AWS::EC2::Subnet::Id'
+                - VpcId
+            - 'Fn::RefAll': 'AWS::EC2::VPC::Id'
+        AssertDescription: All subnets must in the VPC.
+Mappings:
+  AWSAMIRegionMap:
+    AMI:
+      MFES40AMI: ES_50_PU05_RH_V1
+    ap-northeast-1:
+      MFES40AMI: ami-05d1842beab710b38
+    ap-northeast-2:
+      MFES40AMI: ami-0cf8cb7aff561c1c6
+    ap-south-1:
+      MFES40AMI: ami-0c298dd9691aba765
+    ap-southeast-1:
+      MFES40AMI: ami-0359dbf0b49908990
+    ap-southeast-2:
+      MFES40AMI: ami-0a564bf05f121468d
+    ca-central-1:
+      MFES40AMI: ami-0af0bef96f2738cb8
+    eu-central-1:
+      MFES40AMI: ami-072da8340c7ac3c90
+    eu-north-1:
+      MFES40AMI: ami-078851e55a0205bd3
+    eu-west-1:
+      MFES40AMI: ami-04fc334c1c571095b
+    eu-west-2:
+      MFES40AMI: ami-0b00fe6f6d1f8cf8a
+    eu-west-3:
+      MFES40AMI: ami-09634aba2e3e9af51
+    sa-east-1:
+      MFES40AMI: ami-0dbc3f6e6eb8cc52c
+    us-east-1:
+      MFES40AMI: ami-0a7658bdbac09c2f5
+    us-east-2:
+      MFES40AMI: ami-0644d10d2c8e259d0
+    us-west-1:
+      MFES40AMI: ami-0eaaa90f16236c7b8
+    us-west-2:
+      MFES40AMI: ami-0a702c05587e75698
+Conditions:
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
+  NamePrefixIaUndefined: !Equals
+    - !Ref ESResourceNamePrefix
+    - ''
+  NamePrefixIsAWSStackname: !Equals
+    - !Ref ESResourceNamePrefix
+    - 'AWS::StackName'
+  HaveNotificationARN: !Not
+    - !Equals
+      - !Ref NotificationARN
+      - ''
+  InstallingFSDemoApp: !Equals
+    - !Ref InstallDemoApps
+    - 'true'
+Resources:
+  FSAccessSG:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security group for allowed access to the Fileshare instance
+      SecurityGroupIngress:
+        - Description: >-
+            Allows access to the Enterprise Server Admin portal from the Bastion
+            hosts
+          IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          SourceSecurityGroupId: !Ref BastionAccessSGID
+        - Description: Fileshare client ingress
+          IpProtocol: tcp
+          FromPort: 3000
+          ToPort: 3000
+          SourceSecurityGroupId: !Ref FSClientAccessSGID
+        - Description: >-
+            Micro Focus Enterprise Server Directory Service (tcp) Listener
+            ingress
+          IpProtocol: tcp
+          FromPort: 86
+          ToPort: 86
+          SourceSecurityGroupId: !Ref FSClientAccessSGID
+        - Description: >-
+            Micro Focus Enterprise Server Directory Service (udp) Listener
+            ingress
+          IpProtocol: udp
+          FromPort: 86
+          ToPort: 86
+          SourceSecurityGroupId: !Ref FSClientAccessSGID
+      VpcId: !Ref VPCID
+  FSInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:GetObject'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+            Version: 2012-10-17
+          PolicyName: aws-quick-start-s3-policy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:*'
+                Effect: Allow
+                Resource:
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+                  - !Sub
+                    - 'arn:${partition}:s3:::${ESS3BucketName}/*'
+                    - partition: !If
+                        - GovCloudCondition
+                        - aws-us-gov
+                        - aws
+          PolicyName: FSInstancePolicy
+  FSInstanceRoleProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: /
+      Roles:
+        - !Ref FSInstanceRole
+  FSPrimaryDataVolume:
+    Type: 'AWS::EC2::Volume'
+    Properties:
+      VolumeType: gp2
+      Size: !Ref FSStorageInGiB
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - '${StackNamePrefix}${FSServerName} Data Volume'
+            - StackNamePrefix: !If
+                - NamePrefixIaUndefined
+                - ''
+                - !If
+                  - NamePrefixIsAWSStackname
+                  - !Sub '${AWS::StackName}-'
+                  - !Sub '${ESResourceNamePrefix}-'
+  FSPrimaryInstance:
+    Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT20M
+    Metadata:
+      'AWS::CloudFormation::Authentication':
+        S3AccessCreds:
+          type: S3
+          roleName: !Ref FSInstanceRole
+          buckets:
+            - !Ref QSS3BucketName
+            - !Ref ESS3BucketName
+      'AWS::CloudFormation::Init':
+        configSets:
+          config:
+            - 000-NoOperation
+            - 010-JoinDomain
+            - 020-ApplyESLicenseFile
+            - !If
+              - InstallingFSDemoApp
+              - 030-ConfigureFileshare
+              - 000-NoOperation
+        000-NoOperation:
+          commands:
+            a-no-operation:
+              command: echo "No-Operation" > nul
+              waitAfterCompletion: '0'
+        010-JoinDomain:
+          files:
+            '/tmp/JoinTo-Domain-Linux.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/JoinTo-Domain-Linux.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/NetworkShare-Setup.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/NetworkShare-Setup.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/RenameHost.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/RenameHost.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-JoinDomain:
+              command: !Sub
+                ./tmp/JoinTo-Domain-Linux.sh Admin ${DomainDNSName} ${DomainAdminPassword}
+              waitAfterCompletion: '0'
+            b-SetupShare:
+              command:
+                ./tmp/NetworkShare-Setup.sh
+              waitAfterCompletion: '0'
+            c-RenameMachine:
+              command: !Sub
+                ./tmp/RenameHost.sh ${DomainDNSName} FSSERVER1
+              waitAfterCompletion: '0'
+        020-ApplyESLicenseFile:
+          files:
+            '/tmp/Enterprise-Server.mflic':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/license/${ESLicenseFilename}
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Start-MFDS.sh':
+              source: !Sub
+                - >-
+                  https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-MFDS.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-install-license:
+              command:
+                ./var/microfocuslicensing/bin/cesadmintool.sh -install /tmp/Enterprise-Server.mflic
+            b-start-mfds:
+              command:
+                ./tmp/Start-MFDS.sh
+        030-ConfigureFileshare:
+          files:
+            '/tmp/fs.conf':
+              content: !Sub |
+                -s FS1,MFPORT:3000
+                -pf /FSdata/pass.dat
+                -cm CCITCP
+              mode: 000550
+              owner: root
+              group: root
+            '/tmp/Enterprise-Server.mflic':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/license/${ESLicenseFilename}
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Setup-Fileshare.sh':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Setup-Fileshare.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+            '/tmp/Start-Fileshare.sh':
+              source: !Sub
+                - >-
+                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/Start-Fileshare.sh
+                - QSS3Region: !If
+                    - GovCloudCondition
+                    - s3-us-gov-west-1
+                    - s3
+              mode: 000550
+              owner: root
+              group: root
+              authentication: S3AccessCreds
+          commands:
+            a-Setup-Fileshare:
+              command: !Sub
+                ./tmp/Setup-Fileshare.sh '${FSVIEWUserPassword}'
+              waitAfterCompletion: '0'
+            b-Start-Fileshare:
+              command:
+                ./tmp/Start-Fileshare.sh
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - !Ref AvailabilityZones
+      ImageId: !FindInMap
+        - AWSAMIRegionMap
+        - !Ref 'AWS::Region'
+        - MFES40AMI
+      SecurityGroupIds:
+        - !Ref DomainMemberSGID
+        - !Ref FSAccessSG
+      IamInstanceProfile: !Ref FSInstanceRoleProfile
+      KeyName: !Ref KeyPairName
+      InstanceType: !Ref FSInstanceType
+      SubnetId: !Ref PrivateSubnet1AID
+      Volumes:
+        - VolumeId: !Ref FSPrimaryDataVolume
+          Device: xvdb
+      Tags:
+        - Key: Name
+          Value: !Sub
+            - '${StackNamePrefix}${FSServerName}'
+            - StackNamePrefix: !If
+                - NamePrefixIaUndefined
+                - ''
+                - !If
+                  - NamePrefixIsAWSStackname
+                  - !Sub '${AWS::StackName}-'
+                  - !Sub '${ESResourceNamePrefix}-'
+      UserData: !Base64
+        'Fn::Join':
+          - ''
+          - - |
+              #!/bin/bash -xe
+            - | 
+              exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+            - >
+              rpm -Uvh
+              https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+            - |
+              yum -y install python-pip
+            - >
+              /bin/easy_install --script-dir /opt/aws/bin 
+              https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+            - >
+              cp -f `pip show aws-cfn-bootstrap 2>/dev/null|grep -E "^Location"|awk
+              -F: '{print $2}'`/init/redhat/cfn-hup /etc/init.d/
+            - |
+              chmod 755 /etc/init.d/cfn-hup
+              chkconfig --add cfn-hup
+            - >-
+              /opt/aws/bin/cfn-init -v --stack 
+            - !Ref 'AWS::StackName' 
+            - ' --resource FSPrimaryInstance
+              --configsets config 
+              --region '
+            - !Ref 'AWS::Region'
+            - |+
+            
+            - '/opt/aws/bin/cfn-signal -e $? --stack '
+            - !Ref 'AWS::StackName'
+            - ' --resource FSPrimaryInstance --region '
+            - !Ref 'AWS::Region'
+            - |+
+  FSPrimaryInstanceRecoveryAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmDescription: !Sub |
+        "${AWS::StackName} Stack instance auto-recovery alarm/trigger."
+      Namespace: AWS/EC2
+      MetricName: StatusCheckFailed_System
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 5
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0
+      AlarmActions:
+        - !Sub 'arn:aws:automate:${AWS::Region}:ec2:recover'
+        - !If
+          - HaveNotificationARN
+          - !Ref NotificationARN
+          - !Ref 'AWS::NoValue'
+      Dimensions:
+        - Name: InstanceId
+          Value: !Ref FSPrimaryInstance
+Outputs:
+  FSInstanceAvailabilityZone:
+    Description: The Availability Zone where the Fileshare instance is launched
+    Value: !GetAtt FSPrimaryInstance.AvailabilityZone
+  FSInstancePrivateDnsName:
+    Description: The private DNS name of the Fileshare instance
+    Value: !Join
+      - .
+      - - !Ref FSServerName
+        - !Ref DomainDNSName
+  FileshareDataFolderUNC:
+    Description: UNC of the Fileshare data folder
+    Value: !Sub '\\${FSServerName}\fsdir'

--- a/templates/mf-fs-template.yaml
+++ b/templates/mf-fs-template.yaml
@@ -49,7 +49,6 @@ Metadata:
         Parameters:
           - FSInstanceType
           - FSStorageInGiB
-          - FSCCITCPListenerPort
           - FSVIEWUserPassword
           - FSServerName
           - KeyPairName
@@ -88,8 +87,6 @@ Metadata:
         default: Enterprise Server S3 bucket name
       FSInstanceType:
         default: Enterprise Server Fileshare instance type
-      FSCCITCPListenerPort:
-        default: Enterprise Server Fileshare CCITCP listener port
       FSClientAccessSGID:
         default: ES Client Access Security Group ID
       FSServerName:
@@ -178,13 +175,6 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot
       start or end with a hyphen (-).
     Type: String
-  FSCCITCPListenerPort:
-    ConstraintDescription: The port number must be between 1 and 65535.
-    Default: 3000
-    Description: The TCP port in the range 1-65535.
-    MaxValue: 65535
-    MinValue: 1
-    Type: Number
   FSClientAccessSGID:
     Type: 'AWS::EC2::SecurityGroup::Id'
     Description: >-
@@ -312,39 +302,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_40PU4_V3
+      MFES40AMI: ES_50_PU05
     ap-northeast-1:
-      MFES40AMI: ami-0d8abeda47ca57871
+      MFES40AMI: ami-0dff3f5a16ecacfe5
     ap-northeast-2:
-      MFES40AMI: ami-05dccbfcdcf0adf6f
+      MFES40AMI: ami-0248d8806a80ec1be
     ap-south-1:
-      MFES40AMI: ami-09beff70828ed8de7
+      MFES40AMI: ami-07c28d590f4c42580
     ap-southeast-1:
-      MFES40AMI: ami-056340469fc88e360
+      MFES40AMI: ami-0a8d6fe92bdb3a94f
     ap-southeast-2:
-      MFES40AMI: ami-00f7e3a908d0e4499
+      MFES40AMI:  ami-05d45ddc80bfd6446
     ca-central-1:
-      MFES40AMI: ami-09b7e0eccba7305d5
+      MFES40AMI: ami-0f0adf2454aa54382
     eu-central-1:
-      MFES40AMI: ami-0748eb1177837591c
+      MFES40AMI: ami-00664de4c7c03a310
     eu-north-1:
-      MFES40AMI: ami-0dbf576f5ad8a6bbd
+      MFES40AMI: ami-09a1a20c436e7806e
     eu-west-1:
-      MFES40AMI: ami-0afd368a7655b6dfb
+      MFES40AMI: ami-03e0b7531700529c5
     eu-west-2:
-      MFES40AMI: ami-0619eb00e92ab7b00
+      MFES40AMI: ami-0ed05eb873c2da4ef
     eu-west-3:
-      MFES40AMI: ami-02eaa14fb48885cc9
+      MFES40AMI: ami-0dd39cc30ea3574b7
     sa-east-1:
-      MFES40AMI: ami-01bba1206e8807019
+      MFES40AMI: ami-082e4e947dbbf35b1
     us-east-1:
-      MFES40AMI: ami-0a4603cadffc7170d
+      MFES40AMI: ami-0e6255dfab3d7497c
     us-east-2:
-      MFES40AMI: ami-0a2b689af8ad19ff3
+      MFES40AMI: ami-048a75e3c74fdfa5f
     us-west-1:
-      MFES40AMI: ami-09577a4bbdc01a65d
+      MFES40AMI: ami-074e117de783cab22
     us-west-2:
-      MFES40AMI: ami-047e3be248b380812
+      MFES40AMI: ami-09dc8cff0a367fa32
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
@@ -374,8 +364,8 @@ Resources:
           SourceSecurityGroupId: !Ref RDGWAccessSGID
         - Description: Fileshare client ingress
           IpProtocol: tcp
-          FromPort: !Ref FSCCITCPListenerPort
-          ToPort: !Ref FSCCITCPListenerPort
+          FromPort: 3000
+          ToPort: 3000
           SourceSecurityGroupId: !Ref FSClientAccessSGID
         - Description: >-
             Micro Focus Enterprise Server Directory Service (tcp) Listener
@@ -477,7 +467,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT50M
+        Timeout: PT25M
     Metadata:
       'AWS::CloudFormation::Authentication':
         S3AccessCreds:
@@ -502,15 +492,9 @@ Resources:
             'c:\cfn\assets\GoogleChromeStandaloneEnterprise64.msi':
               source: >-
                 https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise64.msi
-            'c:\cfn\assets\npp.Installer.x64.exe':
-              source: >-
-                https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.8.1/npp.7.8.1.Installer.exe
           commands:
             a-install-aws-cli:
               command: 'start /wait c:\cfn\assets\AWSCLI64PY3.msi /quiet /passive /qn'
-              waitAfterCompletion: '0'
-            b-install-npp:
-              command: 'start /wait c:\cfn\assets\npp.Installer.x64.exe /S'
               waitAfterCompletion: '0'
             c-install-chrome:
               command: >-
@@ -803,7 +787,7 @@ Resources:
           files:
             'd:\fsdir\fs.conf':
               content: !Sub |
-                /s FS1,MFPORT:${FSCCITCPListenerPort}
+                /s FS1,MFPORT:3000
                 /pf d:\fsdir\pass.dat
                 /wd d:\fsdir
                 /cm CCITCP
@@ -876,11 +860,11 @@ Resources:
                     -Protocol udp
               waitAfterCompletion: '0'
             g-configure-windows-firewall-fs-ccitcp-listener-rule:
-              command: !Sub
+              command:
                 powershell.exe
                   -Command New-NetFirewallRule
                     -DisplayName 'Micro Focus Enterprise Server (Fileshare) CCITCP Listener'
-                    -LocalPort ${FSCCITCPListenerPort}
+                    -LocalPort 3000
                     -Protocol tcp
               waitAfterCompletion: '0'
             h-install-fs-service:


### PR DESCRIPTION
This adds a Linux version of the quick start based on Redhat Enterprise Linux. Also added is a new version of the Bankdemo using the PAC. If selected this will setup Elasticache for Redis and deploys the Bankdemo VSAM files into Amazon aurora. In addition the AMIs have been updated to Enterprise Server 5.0 PU05.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
