### PR TITLE
Updated all AMIs to use Enterprise Server 6.0 PU01...

### DIFF
--- a/scripts/Download-postgres-tools.ps1
+++ b/scripts/Download-postgres-tools.ps1
@@ -1,0 +1,10 @@
+try {
+    Start-Transcript -Path c:\cfn\log\$($MyInvocation.MyCommand.Name).txt -Append -IncludeInvocationHeader;
+    $ErrorActionPreference = "Stop";
+    New-Item -ItemType Directory -Force -Path "c:\cfn\assets\"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest "https://get.enterprisedb.com/postgresql/postgresql-11.5-1-windows-x64.exe" -outfile "c:\cfn\assets\postgres-11-winx64.exe"
+}
+catch {
+    $_ | Write-AWSQuickStartException
+}

--- a/templates/mf-es-bootstrap-template.yaml
+++ b/templates/mf-es-bootstrap-template.yaml
@@ -572,8 +572,12 @@ Resources:
               waitAfterCompletion: '0'
         040-Setup-PAC-Database-Environment:
           files:
-            'c:\cfn\assets\postgres-11-winx64.exe':
-              source: https://get.enterprisedb.com/postgresql/postgresql-11.5-1-windows-x64.exe
+            'c:\cfn\scripts\Download-postgres-tools.ps1':
+              source: !Sub
+                - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/Download-postgres-tools.ps1
+                - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+                  S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              authentication: S3AccessCreds
             'c:\cfn\scripts\Prep-PACDemoDatabase.ps1':
               source: !Sub
                 - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/Prep-PACDemoDatabase.ps1
@@ -595,21 +599,26 @@ Resources:
                   S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
               authentication: S3AccessCreds
           commands:
-            a-install-postgres-tools:
+            a-download-postgres-tools:
+              command:
+                'powershell.exe -File C:\cfn\scripts\Download-postgres-tools.ps1'
+              waitAfterCompletion: '0'
+            b-install-postgres-tools:
               command: !Sub 'powershell.exe -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1 
-              -TaskName Install-Postgres-Tools -TaskArguments "-File c:\cfn\scripts\Install-Postgres-Tools.ps1"
-              -DomainUserName "${DomainNetBIOSName}\Admin" -DomainUserPassword "${DomainAdminPassword}"'
-            b-schedule-add-database-cname-to-dns:
+                -TaskName Install-Postgres-Tools -TaskArguments "-File c:\cfn\scripts\Install-Postgres-Tools.ps1"
+                -DomainUserName "${DomainNetBIOSName}\Admin" -DomainUserPassword "${DomainAdminPassword}"'
+              waitAfterCompletion: '90'
+            c-schedule-add-database-cname-to-dns:
               command: !Sub 'powershell.exe -File C:\cfn\scripts\Schedule-AD-AddDNSServerResourceRecordCName.ps1
                 -CName ESPACDatabase -HostNameAlias ${ESPACDatabaseEndpointAddress} -DomainDnsName
                 ${DomainDNSName} -DomainUserName Admin -DomainUserPassword ${DomainAdminPassword}'
               waitAfterCompletion: '0'
-            c-configure-database:
+            d-configure-database:
               cwd: 'C:\Program Files\PostgreSQL\11\bin'
               command: !Sub 'powershell.exe -File c:\cfn\scripts\Prep-PACDemoDatabase.ps1 -DBMasterUsername ${PACDBMasterUsername}
                 -DBMasterUserPassword ${PACDBMasterUserPassword}'
               waitAfterCompletion: '0'
-            d-schedule-add-redis-cname-to-dns:
+            e-schedule-add-redis-cname-to-dns:
               command: !Sub 'powershell.exe -File C:\cfn\scripts\Schedule-AD-AddDNSServerResourceRecordCName.ps1
                 -CName ESRedis -HostNameAlias ${RedisEndPoint} -DomainDnsName
                 ${DomainDNSName} -DomainUserName Admin -DomainUserPassword ${DomainAdminPassword}'

--- a/templates/mf-es-master-template.yaml
+++ b/templates/mf-es-master-template.yaml
@@ -1162,7 +1162,7 @@ Resources:
         NumberOfRDGWHosts: !Ref NumberOfRDGWHosts
         PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
         PublicSubnet2ID: !GetAtt VPCStack.Outputs.PublicSubnet2ID
-        QSS3BucketName: aws-quickstart
+        QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-microsoft-rdgateway/
         RDGWCIDR: !Ref RDGWCIDR

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -318,39 +318,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_50_PU05_RH_V1
+      MFES40AMI: ES_60_PU01_RH_V1
     ap-northeast-1:
-      MFES40AMI: ami-05d1842beab710b38
+      MFES40AMI: ami-05960a57ebd5c5fa3
     ap-northeast-2:
-      MFES40AMI: ami-0cf8cb7aff561c1c6
+      MFES40AMI: ami-0b0415a9b6d384f27
     ap-south-1:
-      MFES40AMI: ami-0c298dd9691aba765
+      MFES40AMI: ami-0d0442cfd2c2f1c7a
     ap-southeast-1:
-      MFES40AMI: ami-0359dbf0b49908990
+      MFES40AMI: ami-0293084bb483fe506
     ap-southeast-2:
-      MFES40AMI: ami-0a564bf05f121468d
+      MFES40AMI: ami-032474ecc3322864e
     ca-central-1:
-      MFES40AMI: ami-0af0bef96f2738cb8
+      MFES40AMI: ami-0f9b7b1967f2af76d
     eu-central-1:
       MFES40AMI: ami-072da8340c7ac3c90
     eu-north-1:
-      MFES40AMI: ami-078851e55a0205bd3
+      MFES40AMI: ami-0cb5cdae39af65e38
     eu-west-1:
-      MFES40AMI: ami-04fc334c1c571095b
+      MFES40AMI: ami-0d912fc5fb35a1518
     eu-west-2:
-      MFES40AMI: ami-0b00fe6f6d1f8cf8a
+      MFES40AMI: ami-09fd6e481820a31c1
     eu-west-3:
-      MFES40AMI: ami-09634aba2e3e9af51
+      MFES40AMI: ami-0bb15fa6a1211242b
     sa-east-1:
-      MFES40AMI: ami-0dbc3f6e6eb8cc52c
+      MFES40AMI: ami-0c03148647a303bf2
     us-east-1:
-      MFES40AMI: ami-0a7658bdbac09c2f5
+      MFES40AMI: ami-0363db79d74750f4f
     us-east-2:
-      MFES40AMI: ami-0644d10d2c8e259d0
+      MFES40AMI: ami-07bae3b4993f74638
     us-west-1:
-      MFES40AMI: ami-0eaaa90f16236c7b8
+      MFES40AMI: ami-09c135e2f738e08cb
     us-west-2:
-      MFES40AMI: ami-0a702c05587e75698
+      MFES40AMI: ami-08dcd5f1cebf6ef75
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GovCloudCondition: !Equals

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -347,39 +347,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_50_PU05
+      MFES40AMI: ES_60_PU01
     ap-northeast-1:
-      MFES40AMI: ami-0dff3f5a16ecacfe5
+      MFES40AMI: ami-0bae6d1d03ad5c38c
     ap-northeast-2:
-      MFES40AMI: ami-0248d8806a80ec1be
+      MFES40AMI: ami-080a4712b1e7350ed
     ap-south-1:
-      MFES40AMI: ami-07c28d590f4c42580
+      MFES40AMI: ami-0f2b2823ac1d8f95d
     ap-southeast-1:
-      MFES40AMI: ami-0a8d6fe92bdb3a94f
+      MFES40AMI: ami-0065e05aaecced65a
     ap-southeast-2:
-      MFES40AMI:  ami-05d45ddc80bfd6446
+      MFES40AMI:  ami-0de81adc57c6df12a
     ca-central-1:
-      MFES40AMI: ami-0f0adf2454aa54382
+      MFES40AMI: ami-0c4ea4d6fba07f0ee
     eu-central-1:
-      MFES40AMI: ami-00664de4c7c03a310
+      MFES40AMI: ami-08dde1e820f9f5ef9
     eu-north-1:
-      MFES40AMI: ami-09a1a20c436e7806e
+      MFES40AMI: ami-0e2813f8efc423d3f
     eu-west-1:
-      MFES40AMI: ami-03e0b7531700529c5
+      MFES40AMI: ami-0be7439f5e8e1c577
     eu-west-2:
-      MFES40AMI: ami-0ed05eb873c2da4ef
+      MFES40AMI: ami-001842da48968696d
     eu-west-3:
-      MFES40AMI: ami-0dd39cc30ea3574b7
+      MFES40AMI: ami-0c479b1af672abf62
     sa-east-1:
-      MFES40AMI: ami-082e4e947dbbf35b1
+      MFES40AMI: ami-08d30d58645251f63
     us-east-1:
-      MFES40AMI: ami-0e6255dfab3d7497c
+      MFES40AMI: ami-0f308ab79b6c2d1e8
     us-east-2:
-      MFES40AMI: ami-048a75e3c74fdfa5f
+      MFES40AMI: ami-0b0fcb621219073d3
     us-west-1:
-      MFES40AMI: ami-074e117de783cab22
+      MFES40AMI: ami-01d36394b9ba7bc6b
     us-west-2:
-      MFES40AMI: ami-09dc8cff0a367fa32
+      MFES40AMI: ami-0526b4845e872052b
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GovCloudCondition: !Equals

--- a/templates/mf-escwa-template.yaml
+++ b/templates/mf-escwa-template.yaml
@@ -251,39 +251,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_50_PU05
+      MFES40AMI: ES_60_PU01
     ap-northeast-1:
-      MFES40AMI: ami-0dff3f5a16ecacfe5
+      MFES40AMI: ami-0bae6d1d03ad5c38c
     ap-northeast-2:
-      MFES40AMI: ami-0248d8806a80ec1be
+      MFES40AMI: ami-080a4712b1e7350ed
     ap-south-1:
-      MFES40AMI: ami-07c28d590f4c42580
+      MFES40AMI: ami-0f2b2823ac1d8f95d
     ap-southeast-1:
-      MFES40AMI: ami-0a8d6fe92bdb3a94f
+      MFES40AMI: ami-0065e05aaecced65a
     ap-southeast-2:
-      MFES40AMI:  ami-05d45ddc80bfd6446
+      MFES40AMI:  ami-0de81adc57c6df12a
     ca-central-1:
-      MFES40AMI: ami-0f0adf2454aa54382
+      MFES40AMI: ami-0c4ea4d6fba07f0ee
     eu-central-1:
-      MFES40AMI: ami-00664de4c7c03a310
+      MFES40AMI: ami-08dde1e820f9f5ef9
     eu-north-1:
-      MFES40AMI: ami-09a1a20c436e7806e
+      MFES40AMI: ami-0e2813f8efc423d3f
     eu-west-1:
-      MFES40AMI: ami-03e0b7531700529c5
+      MFES40AMI: ami-0be7439f5e8e1c577
     eu-west-2:
-      MFES40AMI: ami-0ed05eb873c2da4ef
+      MFES40AMI: ami-001842da48968696d
     eu-west-3:
-      MFES40AMI: ami-0dd39cc30ea3574b7
+      MFES40AMI: ami-0c479b1af672abf62
     sa-east-1:
-      MFES40AMI: ami-082e4e947dbbf35b1
+      MFES40AMI: ami-08d30d58645251f63
     us-east-1:
-      MFES40AMI: ami-0e6255dfab3d7497c
+      MFES40AMI: ami-0f308ab79b6c2d1e8
     us-east-2:
-      MFES40AMI: ami-048a75e3c74fdfa5f
+      MFES40AMI: ami-0b0fcb621219073d3
     us-west-1:
-      MFES40AMI: ami-074e117de783cab22
+      MFES40AMI: ami-01d36394b9ba7bc6b
     us-west-2:
-      MFES40AMI: ami-09dc8cff0a367fa32
+      MFES40AMI: ami-0526b4845e872052b
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GovCloudCondition: !Equals

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -292,39 +292,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_50_PU05_RH_V1
+      MFES40AMI: ES_60_PU01_RH_V1
     ap-northeast-1:
-      MFES40AMI: ami-05d1842beab710b38
+      MFES40AMI: ami-05960a57ebd5c5fa3
     ap-northeast-2:
-      MFES40AMI: ami-0cf8cb7aff561c1c6
+      MFES40AMI: ami-0b0415a9b6d384f27
     ap-south-1:
-      MFES40AMI: ami-0c298dd9691aba765
+      MFES40AMI: ami-0d0442cfd2c2f1c7a
     ap-southeast-1:
-      MFES40AMI: ami-0359dbf0b49908990
+      MFES40AMI: ami-0293084bb483fe506
     ap-southeast-2:
-      MFES40AMI: ami-0a564bf05f121468d
+      MFES40AMI: ami-032474ecc3322864e
     ca-central-1:
-      MFES40AMI: ami-0af0bef96f2738cb8
+      MFES40AMI: ami-0f9b7b1967f2af76d
     eu-central-1:
       MFES40AMI: ami-072da8340c7ac3c90
     eu-north-1:
-      MFES40AMI: ami-078851e55a0205bd3
+      MFES40AMI: ami-0cb5cdae39af65e38
     eu-west-1:
-      MFES40AMI: ami-04fc334c1c571095b
+      MFES40AMI: ami-0d912fc5fb35a1518
     eu-west-2:
-      MFES40AMI: ami-0b00fe6f6d1f8cf8a
+      MFES40AMI: ami-09fd6e481820a31c1
     eu-west-3:
-      MFES40AMI: ami-09634aba2e3e9af51
+      MFES40AMI: ami-0bb15fa6a1211242b
     sa-east-1:
-      MFES40AMI: ami-0dbc3f6e6eb8cc52c
+      MFES40AMI: ami-0c03148647a303bf2
     us-east-1:
-      MFES40AMI: ami-0a7658bdbac09c2f5
+      MFES40AMI: ami-0363db79d74750f4f
     us-east-2:
-      MFES40AMI: ami-0644d10d2c8e259d0
+      MFES40AMI: ami-07bae3b4993f74638
     us-west-1:
-      MFES40AMI: ami-0eaaa90f16236c7b8
+      MFES40AMI: ami-09c135e2f738e08cb
     us-west-2:
-      MFES40AMI: ami-0a702c05587e75698
+      MFES40AMI: ami-08dcd5f1cebf6ef75
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GovCloudCondition: !Equals

--- a/templates/mf-fs-template.yaml
+++ b/templates/mf-fs-template.yaml
@@ -309,39 +309,39 @@ Rules:
 Mappings:
   AWSAMIRegionMap:
     AMI:
-      MFES40AMI: ES_50_PU05
+      MFES40AMI: ES_60_PU01
     ap-northeast-1:
-      MFES40AMI: ami-0dff3f5a16ecacfe5
+      MFES40AMI: ami-0bae6d1d03ad5c38c
     ap-northeast-2:
-      MFES40AMI: ami-0248d8806a80ec1be
+      MFES40AMI: ami-080a4712b1e7350ed
     ap-south-1:
-      MFES40AMI: ami-07c28d590f4c42580
+      MFES40AMI: ami-0f2b2823ac1d8f95d
     ap-southeast-1:
-      MFES40AMI: ami-0a8d6fe92bdb3a94f
+      MFES40AMI: ami-0065e05aaecced65a
     ap-southeast-2:
-      MFES40AMI:  ami-05d45ddc80bfd6446
+      MFES40AMI:  ami-0de81adc57c6df12a
     ca-central-1:
-      MFES40AMI: ami-0f0adf2454aa54382
+      MFES40AMI: ami-0c4ea4d6fba07f0ee
     eu-central-1:
-      MFES40AMI: ami-00664de4c7c03a310
+      MFES40AMI: ami-08dde1e820f9f5ef9
     eu-north-1:
-      MFES40AMI: ami-09a1a20c436e7806e
+      MFES40AMI: ami-0e2813f8efc423d3f
     eu-west-1:
-      MFES40AMI: ami-03e0b7531700529c5
+      MFES40AMI: ami-0be7439f5e8e1c577
     eu-west-2:
-      MFES40AMI: ami-0ed05eb873c2da4ef
+      MFES40AMI: ami-001842da48968696d
     eu-west-3:
-      MFES40AMI: ami-0dd39cc30ea3574b7
+      MFES40AMI: ami-0c479b1af672abf62
     sa-east-1:
-      MFES40AMI: ami-082e4e947dbbf35b1
+      MFES40AMI: ami-08d30d58645251f63
     us-east-1:
-      MFES40AMI: ami-0e6255dfab3d7497c
+      MFES40AMI: ami-0f308ab79b6c2d1e8
     us-east-2:
-      MFES40AMI: ami-048a75e3c74fdfa5f
+      MFES40AMI: ami-0b0fcb621219073d3
     us-west-1:
-      MFES40AMI: ami-074e117de783cab22
+      MFES40AMI: ami-01d36394b9ba7bc6b
     us-west-2:
-      MFES40AMI: ami-09dc8cff0a367fa32
+      MFES40AMI: ami-0526b4845e872052b
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   GovCloudCondition: !Equals


### PR DESCRIPTION
Updated all AMIs to use Enterprise Server 6.0 PU01.
Fixed issue where the postgres tools installer was failing to download due to the site now requiring tls 1.2+. This is now downloaded by a powershell script with tls 1.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
