### PR TITLE
Correct ami-id for ca-central-1

### DIFF
--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -330,7 +330,7 @@ Mappings:
     ap-southeast-2:
       MFES40AMI: ami-032474ecc3322864e
     ca-central-1:
-      MFES40AMI: ami-0f9b7b1967f2af76d
+      MFES40AMI: ami-08586e4e410b9f7e1
     eu-central-1:
       MFES40AMI: ami-072da8340c7ac3c90
     eu-north-1:

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -304,7 +304,7 @@ Mappings:
     ap-southeast-2:
       MFES40AMI: ami-032474ecc3322864e
     ca-central-1:
-      MFES40AMI: ami-0f9b7b1967f2af76d
+      MFES40AMI: ami-08586e4e410b9f7e1
     eu-central-1:
       MFES40AMI: ami-072da8340c7ac3c90
     eu-north-1:


### PR DESCRIPTION
Corrected the ca-central-1 ami-id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
