### PR TITLE
Fixed bugs to get QS back to working order

### DIFF
--- a/templates/mf-db-aurora-template.yaml
+++ b/templates/mf-db-aurora-template.yaml
@@ -165,7 +165,7 @@ Resources:
     Type: AWS::RDS::DBCluster
     Properties:
       Engine: aurora-postgresql
-      EngineVersion: "10.7"
+      EngineVersion: "10"
       MasterUsername: !Ref DBMasterUsername
       MasterUserPassword: !Ref DBMasterUserPassword
       DBSubnetGroupName: !Ref DatabaseSubnetGroup

--- a/templates/mf-db-template.yaml
+++ b/templates/mf-db-template.yaml
@@ -279,7 +279,7 @@ Resources:
         - !GetAtt ESDatabaseSG.GroupId
       LicenseModel: license-included
       Engine: sqlserver-se
-      EngineVersion: 14.00.3035.2.v1
+      EngineVersion: "14.00"
       MultiAZ: !Ref DeployMultiAZ
       DBInstanceClass: !Ref DBInstanceClass
       AllocatedStorage: !Ref DBStorageInGiB

--- a/templates/mf-es-master-template.yaml
+++ b/templates/mf-es-master-template.yaml
@@ -1319,4 +1319,4 @@ Outputs:
   RemoteDesktopGatewayIP:
     Condition: IncludeRDGW
     Description: Public IP Address for the Remote Desktop Gateway
-    Value: !GetAtt RDGWStack.Outputs.EIP1
+    Value: !GetAtt RDGWStack.Outputs.RDPURL

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -928,11 +928,8 @@ Resources:
             'd:\esdir\Enterprise-Server.mflic':
               source: !Sub
                 - >-
-                  https://${ESS3BucketName}.${QSS3Region}.amazonaws.com/license/${ESLicenseFilename}
-                - QSS3Region: !If
-                    - GovCloudCondition
-                    - s3-us-gov-west-1
-                    - s3
+                  https://${ESS3BucketName}.s3.${S3Region}.${AWS::URLSuffix}/license/${ESLicenseFilename}
+                - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
               authentication: S3AccessCreds
             'c:\cfn\scripts\MFDS-Listen-all.ps1':
               source: !Sub
@@ -1034,10 +1031,10 @@ Resources:
           files:
             'c:\cfn\assets\psqlodbc1_11_x86.zip':
               source:
-                https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x86.zip
+                http://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x86.zip
             'c:\cfn\assets\psqlodbc1_11_x64.zip':
               source:
-                https://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x64.zip
+                http://ftp.postgresql.org/pub/odbc/versions/msi/psqlodbc_11_01_0000-x64.zip
           commands:
             a-Unzip-PsqlODBC-Driver-x86:
               command:


### PR DESCRIPTION
Issue #, if available:

**Description of changes:**

Modified EngineVersion for DBinstance and DBCluser. Old value caused an error due to a depreciated version, instead only a major version is specified letting AWS use a default minor version.

Output value of submodules/quickstart-microsoft-rdgateway/templates/rdgw-domain.template has changed from EIP1 to RDPURL.

URL used to access the EnterpiseServer License file utilises Signature Version 2 so it was updated to include the region to make of Signature Version 4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.