### PR TITLE
Improved reliability of CFT

### DIFF
--- a/templates/mf-db-aurora-template.yaml
+++ b/templates/mf-db-aurora-template.yaml
@@ -20,6 +20,11 @@ Description: >-
   please review the terms and conditions here
   (https://www.microfocus.com/about/legal/) for further details. (qs-1qeg3mkqr)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W9004
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -69,13 +74,16 @@ Parameters:
       - db.r4.xlarge
       - db.r4.2xlarge
       - db.r4.4xlarge
-      - db.r2.8xlarge
+      - db.r4.8xlarge
     Default: db.r4.large
     Type: String
+    Description: DB instance class
   DBMasterUsername:
+    Description: The master user name for the DB instance.
     Type: String
     Default: DBAdmin
   DBMasterUserPassword:
+    Description: The password for the master user.
     Type: String
     NoEcho: true
   DirectoryServiceID:
@@ -153,7 +161,7 @@ Resources:
                 - rds.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess
   DatabaseSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
@@ -163,6 +171,13 @@ Resources:
         - !Ref PrivateSubnet2AID
   AuroraCluster:
     Type: AWS::RDS::DBCluster
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - ERDSStorageEncryptionEnabled
+          ignore_reasons:
+            - ERDSStorageEncryptionEnabled: "Encryption disabled by design"
     Properties:
       Engine: aurora-postgresql
       EngineVersion: "10"
@@ -176,7 +191,6 @@ Resources:
       VpcSecurityGroupIds:
         - !Ref ESDatabaseSG
       BackupRetentionPeriod: 30
-    DependsOn: DatabaseSubnetGroup
 
   ESDatabase:
     Type: 'AWS::RDS::DBInstance'

--- a/templates/mf-db-template.yaml
+++ b/templates/mf-db-template.yaml
@@ -20,6 +20,11 @@ Description: >-
   please review the terms and conditions here
   (https://www.microfocus.com/about/legal/) for further details. (qs-1p440hhtu)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W9004
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -93,7 +98,7 @@ Parameters:
       - db.r4.xlarge
       - db.r4.2xlarge
       - db.r4.4xlarge
-      - db.r2.8xlarge
+      - db.r4.8xlarge
     Description: The type of Amazon RDS DB instance.
     Default: db.r4.large
     Type: String
@@ -251,7 +256,7 @@ Resources:
                 - rds.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess
   ESDatabase:
     Type: 'AWS::RDS::DBInstance'
     DeletionPolicy: Delete

--- a/templates/mf-es-bootstrap-template.yaml
+++ b/templates/mf-es-bootstrap-template.yaml
@@ -7,6 +7,16 @@ Description: '"This template deploys a single Micro Focus Enterprise Server inst
   separately, please review the terms and conditions here (https://www.microfocus.com/about/legal/)
   for further details. (qs-1p6hinfit)"'
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - E9010
+        - W9002
+        - W9003
+        - W9004
+        - W4002
+        - W2001
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
@@ -98,7 +108,7 @@ Metadata:
         default: Micro Focus Directory Server service domain account name
       MFDSServiceAccountPassword:
         default: Micro Focus Directory Server service account password
-      PACDBMasterUsername: 
+      PACDBMasterUsername:
         default: Database Master username
       PACDBMasterUserPassword:
         default: Database Master password
@@ -234,7 +244,7 @@ Parameters:
     Description: The name of an existing EC2 key pair. All instances will launch with
       this key pair.
     Type: AWS::EC2::KeyPair::KeyName
-  LatestWS2012R2AmiId: 
+  LatestWS2012R2AmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: '/aws/service/ami-windows-latest/Windows_Server-2012-R2_RTM-English-64Bit-Base'
   MFDSServiceAccountName:
@@ -356,6 +366,13 @@ Conditions:
 Resources:
   BTSTRPInstanceRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for bootstrap instance policy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -367,8 +384,9 @@ Resources:
             - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-      - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
       - PolicyDocument:
           Statement:
@@ -649,7 +667,7 @@ Resources:
                 'powershell.exe -File C:\cfn\scripts\Download-postgres-tools.ps1'
               waitAfterCompletion: '0'
             b-install-postgres-tools:
-              command: !Sub 'powershell.exe -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1 
+              command: !Sub 'powershell.exe -File c:\cfn\scripts\Schedule-AD-PowershellTask.ps1
                 -TaskName Install-Postgres-Tools -TaskArguments "-File c:\cfn\scripts\Install-Postgres-Tools.ps1"
                 -DomainUserName "${DomainNetBIOSName}\Admin" -DomainUserPassword "${DomainAdminPassword}"'
               waitAfterCompletion: '90'

--- a/templates/mf-es-bootstrap-template.yaml
+++ b/templates/mf-es-bootstrap-template.yaml
@@ -30,6 +30,7 @@ Metadata:
       - MFDSServiceAccountPassword
       - ESS3BucketName
       - ESS3BucketRegion
+      - ESCWLogGroup
     - Label:
         default: PAC Configuration
       Parameters:
@@ -75,6 +76,8 @@ Metadata:
         default: Domain member Security Group ID
       ESClientAccessSGID:
         default: ES Client Access Security Group ID
+      ESCWLogGroup:
+        default: Amazon CloudWatch Log Group
       ESDemoUserPassword:
         default: Enterprise Server Demo User password
       ESDatabaseEndpointAddress:
@@ -163,6 +166,9 @@ Parameters:
     Type: AWS::EC2::SecurityGroup::Id
     Description: Security Group ID for application ingress into the Enterpriser Server
       instance (e.g., sg-1234abcd).
+  ESCWLogGroup:
+    Type: String
+    Description: The logical ID of the Amazon CloudWatch Logs Log Group
   ESDatabaseEndpointAddress:
     Type: String
     Description: The connection endpoint for the database
@@ -415,6 +421,7 @@ Resources:
         configSets:
           config:
           - 010-InitPowerShell
+          - 011-ConfigureCW
           - 020-RenameAndJoinDomain
           - !If
             - HaveDatabaseEnvironment
@@ -529,6 +536,37 @@ Resources:
               command: !Sub 'powershell.exe -Command New-AWSQuickStartResourceSignal
                 -Stack ${AWS::StackName} -Resource BTSTRPInstance -Region ${AWS::Region}'
               waitAfterCompletion: '0'
+        011-ConfigureCW:
+          files:
+            "C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent.json":
+              content: !Sub |
+                {
+                  "logs": {
+                    "logs_collected": {
+                      "files": {
+                        "collect_list": [
+                          {
+                            "file_path": "C:\\cfn\\log\\cfn-init.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "BTSTRP/{instance_id}/cfn-init.log"
+                          },
+                          {
+                            "file_path": "C:\\cfn\\log\\cfn-init-cmd.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "BTSTRP/{instance_id}/cfn-init-cmd.log"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+          commands:
+            a-stop-cwagent:
+              command: powershell -Command "C:\\'Program Files'\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1 -a stop"
+              waitAfterCompletion: '30'
+            b-start-cwagent:
+              command: powershell -Command "C:\\'Program Files'\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent.json -s"
+              waitAfterCompletion: '30'
         020-RenameAndJoinDomain:
           commands:
             a-rename-computer:
@@ -731,6 +769,11 @@ Resources:
               rem Uninstall Amazon SSM Agent and AWS CLI to allow updating
               wmic product where "description='Amazon SSM Agent' " uninstall
               wmic product where "description='aws-cfn-bootstrap' " uninstall
+
+              rem Install Unified CloudWatchAgent
+              mkdir C:\Downloads\Amazon\AmazonCloudWatchAgent
+              powershell -Command "(New-Object Net.WebClient).DownloadFile('https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi','C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi')"
+              C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi
 
               rem Install latest AWS CloudFormation Helper Scripts
               start /wait c:\Windows\system32\msiexec /passive /qn /i https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-win64-latest.msi

--- a/templates/mf-es-master-template.yaml
+++ b/templates/mf-es-master-template.yaml
@@ -21,6 +21,11 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1p6hinfg3)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -212,7 +217,7 @@ Metadata:
         default: Operator email address
       PACDBInstanceClass:
         default: Database instance class
-      PACDBMasterUsername: 
+      PACDBMasterUsername:
         default: PAC database Master username
       PACDBMasterUserPassword:
         default: PAC database Master password
@@ -332,7 +337,7 @@ Parameters:
       printable ASCII character except "/", """, or "@".
     Description: >-
       The password for the DB master user. Must be at least eight characters
-      long, as in "mypassword". Can be any printable ASCII character 
+      long, as in "mypassword". Can be any printable ASCII character
       except "/", """, or "@".
     Type: String
     NoEcho: true
@@ -948,9 +953,9 @@ Rules:
             #- me-south-1         # Middle East (Bahrain) --> MFES not available
             - sa-east-1          # South America (Sao Paulo)
             # - us-gov-east-1      # AWS GovCloud (US-East) --> GovCloud not supported
-            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported 
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported
           - !Ref AWS::Region
-        AssertDescription: Micro Focus is not currently supporting this Quick Start in 
+        AssertDescription: Micro Focus is not currently supporting this Quick Start in
           the chosen region. Please contact Micro Focus or launch into a different region.
   LicenseAgreementRule:
     Assertions:
@@ -1006,9 +1011,6 @@ Conditions:
   InstallingSQLDemoApp: !Equals
     - !Ref InstallSQLDemoApp
     - 'true'
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
 Resources:
   VPCStack:
     Type: 'AWS::CloudFormation::Stack'

--- a/templates/mf-es-master-template.yaml
+++ b/templates/mf-es-master-template.yaml
@@ -784,13 +784,25 @@ Parameters:
     Type: String
   RDGWInstanceType:
     AllowedValues:
-      - t2.small
-      - t2.medium
       - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.micro
+      - t3a.small
+      - t3a.medium
+      - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
       - m5.large
       - m5.xlarge
       - m5.2xlarge
-      - m5.4xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
     Default: t2.large
     Description: The Amazon EC2 instance type for the Remote Desktop Gateway instances.
     Type: String

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -22,6 +22,13 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1qeg3mkuj)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W4002
+        - W9004
+
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -360,9 +367,6 @@ Mappings:
       MFES40AMI: ami-0e9d4a9ef3e4fb89a
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
   HaveESlicenseFilename: !Not
     - !Equals
       - !Ref ESLicenseFilename
@@ -383,6 +387,13 @@ Conditions:
 Resources:
   ESInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for instance policy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -394,8 +405,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:
@@ -431,7 +443,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Effect: Allow
                 Resource:
-                  - !Sub 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+                  - !Sub 'arn:${AWS::Partition}:logs:*:*:log-group:${ESCWLogGroup}*'
           PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -453,7 +465,7 @@ Resources:
               - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
     DeletionPolicy: Delete
@@ -910,7 +922,7 @@ Resources:
           - ''
           - - |
               #!/bin/bash -xe
-            - | 
+            - |
               exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             - >
               for i in 1 2 3 4 5; do rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && break || sleep 2m; done
@@ -926,14 +938,14 @@ Resources:
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
             - >-
-              /bin/cfn-init -v --stack 
-            - !Ref 'AWS::StackName' 
+              /bin/cfn-init -v --stack
+            - !Ref 'AWS::StackName'
             - ' --resource ESInstance
-              --configsets config 
+              --configsets config
               --region '
             - !Ref 'AWS::Region'
             - |+
-            
+
             - '/bin/cfn-signal -e $? --stack '
             - !Ref 'AWS::StackName'
             - ' --resource ESInstance --region '

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -484,7 +484,7 @@ Resources:
             var result = (parseInt(props.RegionsPerInstance) * parseInt(props.RegionStorageOverheadInGiB)) + parseInt(props.AdditionalESStorageinGiB);
             response.send(event, context, response.SUCCESS, {Value: result});
           };
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   ESPrimaryDataVolumeStorageSize:
     Type: 'Custom::CalcPrimaryDataVolumeStorageSizeFunction'
     Properties:
@@ -497,6 +497,7 @@ Resources:
     Type: 'AWS::EC2::Volume'
     Properties:
       VolumeType: gp2
+      Encrypted: true
       Size: !GetAtt ESPrimaryDataVolumeStorageSize.Value
       AvailabilityZone: !Select
         - 0

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -946,7 +946,7 @@ Resources:
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
             - >-
-              /bin/cfn-init -v --stack
+              '/bin/cfn-init -v --stack '
             - !Ref 'AWS::StackName'
             - ' --resource ESInstance
               --configsets config

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -454,6 +454,11 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  LambdaLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
+      RetentionInDays: -1
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -456,6 +456,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
   CalcPrimaryDataVolumeStorageSizeFunction:

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -424,6 +424,15 @@ Resources:
                 Effect: Allow
                 Resource: '*'
           PolicyName: ESInstancePolicy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 'logs:Create*'
+                  - 'logs:PutLogEvents'
+                Effect: Allow
+                Resource:
+                  - 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+          PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -496,6 +505,7 @@ Resources:
         configSets:
           config:
             - 000-NoOperation
+            - 001-ConfigureCW
             - 010-JoinDomain
             - !If
               - HaveESlicenseFilename
@@ -538,6 +548,48 @@ Resources:
             a-no-operation:
               command: echo "No-Operation" > nul
               waitAfterCompletion: '0'
+        001-ConfigureCW:
+          files:
+            /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json:
+              content: !Sub |
+                {
+                  "agent": {
+                    "run_as_user": "root"
+                  },
+                  "logs": {
+                    "logs_collected": {
+                      "files": {
+                        "collect_list": [
+                          {
+                            "file_path": "/var/log/user-data.log",
+                            "log_group_name": "${InstancesLogGroup}",
+                            "log_stream_name": "{instance_id}/user-data.log"
+                          },
+                          {
+                            "file_path": "/var/log/cfn-init.log",
+                            "log_group_name": "${InstancesLogGroup}",
+                            "log_stream_name": "{instance_id}/cfn-init.log"
+                          },
+                          {
+                            "file_path": "/var/log/cfn-init-cmd.log",
+                            "log_group_name": "${InstancesLogGroup}",
+                            "log_stream_name": "{instance_id}/cfn-init-cmd.log"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              mode: '000400'
+              owner: root
+              group: root
+          commands:
+            a-stop-cwagent:
+              command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
+              waitAfterCompletion: '30'
+            b-start-cwagent:
+              command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+              waitAfterCompletion: '30'
         010-JoinDomain:
           files:
             '/tmp/JoinTo-Domain-Linux.sh':
@@ -862,6 +914,8 @@ Resources:
               yum -y install python-pip
             - >
               pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+            - >
+              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
             - >
               cp -f /usr/init/redhat/cfn-hup /etc/init.d/
             - |

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -919,7 +919,7 @@ Resources:
             - >
               pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             - >
-              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
             - >
               cp -f /usr/init/redhat/cfn-hup /etc/init.d/
             - |

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -567,17 +567,17 @@ Resources:
                           {
                             "file_path": "/var/log/user-data.log",
                             "log_group_name": "${ESCWLogGroup}",
-                            "log_stream_name": "{instance_id}/user-data.log"
+                            "log_stream_name": "ES/{instance_id}/user-data.log"
                           },
                           {
                             "file_path": "/var/log/cfn-init.log",
                             "log_group_name": "${ESCWLogGroup}",
-                            "log_stream_name": "{instance_id}/cfn-init.log"
+                            "log_stream_name": "ES/{instance_id}/cfn-init.log"
                           },
                           {
                             "file_path": "/var/log/cfn-init-cmd.log",
                             "log_group_name": "${ESCWLogGroup}",
-                            "log_stream_name": "{instance_id}/cfn-init-cmd.log"
+                            "log_stream_name": "ES/{instance_id}/cfn-init-cmd.log"
                           }
                         ]
                       }

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -431,7 +431,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Effect: Allow
                 Resource:
-                  - 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+                  - !Sub 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
           PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -496,7 +496,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT20M
+        Timeout: PT30M
     Metadata:
       'AWS::CloudFormation::Authentication':
         S3AccessCreds:
@@ -912,8 +912,7 @@ Resources:
             - | 
               exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             - >
-              rpm -Uvh
-              https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+              for i in 1 2 3 4 5; do rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && break || sleep 2m; done
             - |
               yum -y install python-pip
             - >

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -495,6 +495,13 @@ Resources:
       Value: 0
   ESPrimaryDataVolume:
     Type: 'AWS::EC2::Volume'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EBSVolumeEncryption
+          ignore_reasons:
+            - EBSVolumeEncryption: "Ignore invalid check"
     Properties:
       VolumeType: gp2
       Encrypted: true

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -466,11 +466,6 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  LambdaLogGroup:
-    Type: 'AWS::Logs::LogGroup'
-    DeletionPolicy: Delete
-    Properties:
-      LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -945,12 +945,9 @@ Resources:
             - |
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
-            - >-
-              '/bin/cfn-init -v --stack '
+            - '/bin/cfn-init -v --stack '
             - !Ref 'AWS::StackName'
-            - ' --resource ESInstance
-              --configsets config
-              --region '
+            - ' --resource ESInstance --configsets config --region '
             - !Ref 'AWS::Region'
             - |+
 

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -458,7 +458,6 @@ Resources:
     Type: 'AWS::Logs::LogGroup'
     Properties:
       LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
-      RetentionInDays: -1
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/templates/mf-es-redhat-template.yaml
+++ b/templates/mf-es-redhat-template.yaml
@@ -562,17 +562,17 @@ Resources:
                         "collect_list": [
                           {
                             "file_path": "/var/log/user-data.log",
-                            "log_group_name": "${InstancesLogGroup}",
+                            "log_group_name": "${ESCWLogGroup}",
                             "log_stream_name": "{instance_id}/user-data.log"
                           },
                           {
                             "file_path": "/var/log/cfn-init.log",
-                            "log_group_name": "${InstancesLogGroup}",
+                            "log_group_name": "${ESCWLogGroup}",
                             "log_stream_name": "{instance_id}/cfn-init.log"
                           },
                           {
                             "file_path": "/var/log/cfn-init-cmd.log",
-                            "log_group_name": "${InstancesLogGroup}",
+                            "log_group_name": "${ESCWLogGroup}",
                             "log_stream_name": "{instance_id}/cfn-init-cmd.log"
                           }
                         ]

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -618,12 +618,12 @@ Resources:
                           {
                             "file_path": "C:\\cfn\\log\\cfn-init.log",
                             "log_group_name": "${ESCWLogGroup}",
-                            "log_stream_name": "{instance_id}/cfn-init.log"
+                            "log_stream_name": "ES/{instance_id}/cfn-init.log"
                           },
                           {
                             "file_path": "C:\\cfn\\log\\cfn-init-cmd.log",
                             "log_group_name": "${ESCWLogGroup}",
-                            "log_stream_name": "{instance_id}/cfn-init-cmd.log"
+                            "log_stream_name": "ES/{instance_id}/cfn-init-cmd.log"
                           }
                         ]
                       }

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -516,7 +516,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT25M
+        Timeout: PT50M
     Metadata:
       'AWS::CloudFormation::Authentication':
         S3AccessCreds:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -487,9 +487,15 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+  LambdaLogGroup:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
+      RetentionInDays: -1
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
+      FunctionName: !Sub '${AWS::StackName}-'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -489,6 +489,7 @@ Resources:
         - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
+    DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
   CalcPrimaryDataVolumeStorageSizeFunction:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -531,6 +531,13 @@ Resources:
       Value: 0
   ESPrimaryDataVolume:
     Type: 'AWS::EC2::Volume'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EBSVolumeEncryption
+          ignore_reasons:
+            - EBSVolumeEncryption: "Ignore invalid check"
     Properties:
       VolumeType: gp2
       Encrypted: true

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -22,6 +22,13 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1p6hinfje)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W9004
+        - W4002
+
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -416,6 +423,13 @@ Conditions:
 Resources:
   ESInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for instance policy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -427,8 +441,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:
@@ -464,7 +479,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Effect: Allow
                 Resource:
-                  - !Sub 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+                  - !Sub 'arn:${AWS::Partition}:logs:*:*:log-group:${ESCWLogGroup}*'
           PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -486,7 +501,7 @@ Resources:
               - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'
     DeletionPolicy: Delete
@@ -1048,7 +1063,7 @@ Resources:
                       -DsnType "System" `
                       -Platform "32-bit" `
                       -SetPropertyValue @("Server=ESPACDatabase", "UserName=esuser", "Database=postgres", "Password=${PACDBMasterUserPassword}")
-                  
+
                   Add-OdbcDsn `
                       -Name PG.REGION `
                       -DriverName "PostgreSQL ANSI" `
@@ -1255,12 +1270,12 @@ Resources:
               rem Uninstall Amazon SSM Agent and AWS CLI to allow updating
               wmic product where "description='Amazon SSM Agent' " uninstall
               wmic product where "description='aws-cfn-bootstrap' " uninstall
-              
+
               rem Install Unified CloudWatchAgent
               mkdir C:\Downloads\Amazon\AmazonCloudWatchAgent
               powershell -Command "(New-Object Net.WebClient).DownloadFile('https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi','C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi')"
               C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi
-              
+
               rem Install latest AWS CloudFormation Helper Scripts
               start /wait c:\Windows\system32\msiexec /passive /qn /i https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-win64-latest.msi
 

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -494,7 +494,6 @@ Resources:
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-'
       Handler: index.handler
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -502,11 +502,6 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-  LambdaLogGroup:
-    Type: 'AWS::Logs::LogGroup'
-    DeletionPolicy: Delete
-    Properties:
-      LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -491,7 +491,6 @@ Resources:
     Type: 'AWS::Logs::LogGroup'
     Properties:
       LogGroupName: !Sub '/aws/lambda/${CalcPrimaryDataVolumeStorageSizeFunction}'
-      RetentionInDays: -1
   CalcPrimaryDataVolumeStorageSizeFunction:
     Type: 'AWS::Lambda::Function'
     Properties:

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -520,7 +520,7 @@ Resources:
             var result = (parseInt(props.RegionsPerInstance) * parseInt(props.RegionStorageOverheadInGiB)) + parseInt(props.AdditionalESStorageinGiB);
             response.send(event, context, response.SUCCESS, {Value: result});
           };
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   ESPrimaryDataVolumeStorageSize:
     Type: 'Custom::CalcPrimaryDataVolumeStorageSizeFunction'
     Properties:
@@ -533,6 +533,7 @@ Resources:
     Type: 'AWS::EC2::Volume'
     Properties:
       VolumeType: gp2
+      Encrypted: true
       Size: !GetAtt ESPrimaryDataVolumeStorageSize.Value
       AvailabilityZone: !Select
         - 0

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -464,7 +464,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Effect: Allow
                 Resource:
-                  - 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+                  - !Sub 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
           PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/templates/mf-es-template.yaml
+++ b/templates/mf-es-template.yaml
@@ -457,6 +457,15 @@ Resources:
                 Effect: Allow
                 Resource: '*'
           PolicyName: ESInstancePolicy
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 'logs:Create*'
+                  - 'logs:PutLogEvents'
+                Effect: Allow
+                Resource:
+                  - 'arn:aws:logs:*:*:log-group:${ESCWLogGroup}*'
+          PolicyName: ESInstanceLogPolicy
   ESInstanceRoleProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -594,157 +603,35 @@ Resources:
               waitAfterCompletion: '0'
         020-ConfigureCWLogs:
           files:
-            'C:\Program Files\Amazon\SSM\Plugins\awsCloudWatch\AWS.EC2.Windows.CloudWatch.json':
+            "C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent.json":
               content: !Sub |
                 {
-                  "IsEnabled": true,
-                  "EngineConfiguration": {
-                    "PollInterval": "00:00:05",
-                    "Components": [
-                      {
-                        "Id": "ApplicationEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "LogName": "Application",
-                          "Levels": "7"
-                        }
-                      },
-                      {
-                        "Id": "SystemEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "LogName": "System",
-                          "Levels": "7"
-                        }
-                      },
-                      {
-                        "Id": "SecurityEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.EventLog.EventLogInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "LogName": "Security",
-                          "Levels": "7"
-                        }
-                      },
-                      {
-                        "Id": "EC2ConfigLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CustomLog.CustomLogInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "LogDirectoryPath": "C:\\Program Files\\Amazon\\Ec2ConfigService\\Logs",
-                          "TimestampFormat": "yyyy-MM-ddTHH:mm:ss.fffZ:",
-                          "Encoding": "ASCII",
-                          "Filter": "EC2ConfigLog.txt",
-                          "CultureName": "en-US",
-                          "TimeZoneKind": "UTC"
-                        }
-                      },
-                      {
-                        "Id": "CfnInitLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CustomLog.CustomLogInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "LogDirectoryPath": "C:\\cfn\\log",
-                          "TimestampFormat": "yyyy-MM-dd HH:mm:ss,fff",
-                          "Encoding": "ASCII",
-                          "Filter": "cfn-init.log",
-                          "CultureName": "en-US",
-                          "TimeZoneKind": "Local"
-                        }
-                      },
-                      {
-                        "Id": "MemoryPerformanceCounter",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.PerformanceCounterComponent.PerformanceCounterInputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "CategoryName": "Memory",
-                          "CounterName": "Available MBytes",
-                          "InstanceName": "",
-                          "MetricName": "Memory",
-                          "Unit": "Megabytes",
-                          "DimensionName": "",
-                          "DimensionValue": ""
-                        }
-                      },
-                      {
-                        "Id": "CloudWatchApplicationEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "LogGroup": "${ESCWLogGroup}",
-                          "LogStream": "ES/{instance_id}/ApplicationEventLog"
-                        }
-                      },
-                      {
-                        "Id": "CloudWatchSystemEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "LogGroup": "${ESCWLogGroup}",
-                          "LogStream": "ES/{instance_id}/SystemEventLog"
-                        }
-                      },
-                      {
-                        "Id": "CloudWatchSecurityEventLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "LogGroup": "${ESCWLogGroup}",
-                          "LogStream": "ES/{instance_id}/SecurityEventLog"
-                        }
-                      },
-                      {
-                        "Id": "CloudWatchEC2ConfigLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "LogGroup": "${ESCWLogGroup}",
-                          "LogStream": "ES/{instance_id}/EC2ConfigLog"
-                        }
-                      },
-                      {
-                        "Id": "CloudWatchCfnInitLog",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatchLogsOutput,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "LogGroup": "${ESCWLogGroup}",
-                          "LogStream": "ES/{instance_id}/CfnInitLog"
-                        }
-                      },
-                      {
-                        "Id": "CloudWatch",
-                        "FullName": "AWS.EC2.Windows.CloudWatch.CloudWatch.CloudWatchOutputComponent,AWS.EC2.Windows.CloudWatch",
-                        "Parameters": {
-                          "AccessKey": "",
-                          "SecretKey": "",
-                          "Region": "${AWS::Region}",
-                          "NameSpace": "Windows/Default"
-                        }
+                  "logs": {
+                    "logs_collected": {
+                      "files": {
+                        "collect_list": [
+                          {
+                            "file_path": "C:\\cfn\\log\\cfn-init.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "{instance_id}/cfn-init.log"
+                          },
+                          {
+                            "file_path": "C:\\cfn\\log\\cfn-init-cmd.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "{instance_id}/cfn-init-cmd.log"
+                          }
+                        ]
                       }
-                    ],
-                    "Flows": {
-                      "Flows": [
-                        "ApplicationEventLog,CloudWatchApplicationEventLog",
-                        "SystemEventLog,CloudWatchSystemEventLog",
-                        "SecurityEventLog,CloudWatchSecurityEventLog",
-                        "EC2ConfigLog,CloudWatchEC2ConfigLog",
-                        "CfnInitLog,CloudWatchCfnInitLog",
-                        "MemoryPerformanceCounter,CloudWatch"
-                      ]
                     }
                   }
                 }
           commands:
-            a-restartSSM:
-              command: powershell.exe -Command Restart-Service AmazonSSMAgent
-              ignoreErrors: true
-              waitAfterCompletion: 0
+            a-stop-cwagent:
+              command: powershell -Command "C:\\'Program Files'\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1 -a stop"
+              waitAfterCompletion: '30'
+            b-start-cwagent:
+              command: powershell -Command "C:\\'Program Files'\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent.json -s"
+              waitAfterCompletion: '30'
         030-InitPowerShell:
           files:
             'C:\cfn\scripts\Unzip-Archive.ps1':
@@ -1363,7 +1250,12 @@ Resources:
               rem Uninstall Amazon SSM Agent and AWS CLI to allow updating
               wmic product where "description='Amazon SSM Agent' " uninstall
               wmic product where "description='aws-cfn-bootstrap' " uninstall
-
+              
+              rem Install Unified CloudWatchAgent
+              mkdir C:\Downloads\Amazon\AmazonCloudWatchAgent
+              powershell -Command "(New-Object Net.WebClient).DownloadFile('https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi','C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi')"
+              C:\Downloads\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.msi
+              
               rem Install latest AWS CloudFormation Helper Scripts
               start /wait c:\Windows\system32\msiexec /passive /qn /i https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-win64-latest.msi
 

--- a/templates/mf-es-workload-template.yaml
+++ b/templates/mf-es-workload-template.yaml
@@ -1296,6 +1296,7 @@ Resources:
         DomainNetBIOSName: !Ref DomainNetBIOSName
         ESDemoUserPassword: !Ref ESDemoUserPassword
         ESClientAccessSGID: !Ref ESInstance1ClientAccessSecurityGroup
+        ESCWLogGroup: !Ref ESCWLogGroup
         ESDatabaseEndpointAddress: !If
           - CreateRDSRemoteDatabaseStack
           - !GetAtt RemoteDatabaseServerStack.Outputs.ESDatabaseEndpointAddress

--- a/templates/mf-es-workload-template.yaml
+++ b/templates/mf-es-workload-template.yaml
@@ -22,6 +22,10 @@ Description:
   and conditions here (https://www.microfocus.com/about/legal/) for further
   details. (qs-1p6hinfi)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -80,7 +84,6 @@ Metadata:
           - PACDBMasterUsername
           - PACDBMasterUserPassword
           - PACDBMasterUserPasswordConfirm
-          - PACDBStorageInGiB
       - Label:
           default: Enterprise Server Fileshare Configuration
         Parameters:
@@ -207,14 +210,12 @@ Metadata:
         default: Operator email address
       PACDBInstanceClass:
         default: PAC database instance class
-      PACDBMasterUsername: 
+      PACDBMasterUsername:
         default: PAC database Master username
       PACDBMasterUserPassword:
         default: PAC database Master password
       PACDBMasterUserPasswordConfirm:
         default: Re-enter the PAC database Master password
-      PACDBStorageInGiB:
-        default: Database allocated storage size
       PrivateSubnet1AID:
         default: Private Subnet 1A ID
       PrivateSubnet2AID:
@@ -301,7 +302,7 @@ Parameters:
       printable ASCII character except "/", """, or "@".
     Description: >-
       The password for the DB master user. Must be at least eight characters
-      long, as in "mypassword". Can be any printable ASCII character 
+      long, as in "mypassword". Can be any printable ASCII character
       except "/", """, or "@".
     Type: String
     NoEcho: true
@@ -479,12 +480,6 @@ Parameters:
       except "/", """, or "@".
     Type: String
     NoEcho: true
-  PACDBStorageInGiB:
-    Type: Number
-    Description: Enter 20-16384 GiB.
-    MinValue: 20
-    MaxValue: 16384
-    Default: 100
   ESInstanceType:
     AllowedValues:
       - c5.large
@@ -857,9 +852,9 @@ Rules:
             #- me-south-1         # Middle East (Bahrain) --> MFES not available
             - sa-east-1          # South America (Sao Paulo)
             # - us-gov-east-1      # AWS GovCloud (US-East) --> GovCloud not supported
-            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported 
+            # - us-gov-west-1      # AWS GovCloud (US-West) --> GovCloud not supported
           - !Ref AWS::Region
-        AssertDescription: Micro Focus is not currently supporting this Quick Start in 
+        AssertDescription: Micro Focus is not currently supporting this Quick Start in
           the chosen region. Please contact Micro Focus or launch into a different region.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
@@ -1068,6 +1063,13 @@ Resources:
         VPCID: !Ref VPCID
   ESInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for ESInstancePolicy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -1079,8 +1081,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
       Policies:
         - PolicyDocument:
             Statement:

--- a/templates/mf-es-workload-template.yaml
+++ b/templates/mf-es-workload-template.yaml
@@ -1083,7 +1083,7 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:

--- a/templates/mf-escwa-template.yaml
+++ b/templates/mf-escwa-template.yaml
@@ -22,6 +22,13 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1qeg3mku7)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W9004
+        - W4002
+
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -307,6 +314,13 @@ Conditions:
 Resources:
   ESCWAInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for bootstrap instance policy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -318,8 +332,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:
@@ -368,7 +383,7 @@ Resources:
               - 'sts:AssumeRole'
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   ESCWAInstance:
     Type: 'AWS::EC2::Instance'
     CreationPolicy:

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -442,6 +442,13 @@ Resources:
         - !Ref FSInstanceRole
   FSPrimaryDataVolume:
     Type: 'AWS::EC2::Volume'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EBSVolumeEncryption
+          ignore_reasons:
+            - EBSVolumeEncryption: "Ignore invalid check"
     Properties:
       VolumeType: gp2
       Encrypted: true

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -703,7 +703,7 @@ Resources:
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
             - >-
-              /bin/cfn-init -v --stack
+              '/bin/cfn-init -v --stack '
             - !Ref 'AWS::StackName'
             - ' --resource FSPrimaryInstance
               --configsets config

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -702,12 +702,9 @@ Resources:
             - |
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
-            - >-
-              '/bin/cfn-init -v --stack '
+            - '/bin/cfn-init -v --stack '
             - !Ref 'AWS::StackName'
-            - ' --resource FSPrimaryInstance
-              --configsets config
-              --region '
+            - ' --resource FSPrimaryInstance --configsets config --region '
             - !Ref 'AWS::Region'
             - |+
 

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -452,7 +452,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT20M
+        Timeout: PT30M
     Metadata:
       'AWS::CloudFormation::Authentication':
         S3AccessCreds:
@@ -670,8 +670,7 @@ Resources:
             - | 
               exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             - >
-              rpm -Uvh
-              https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+              for i in 1 2 3 4 5; do rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && break || sleep 2m; done
             - |
               yum -y install python-pip
             - >

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -465,6 +465,7 @@ Resources:
         configSets:
           config:
             - 000-NoOperation
+            - 001-ConfigureCW
             - 010-JoinDomain
             - 020-ApplyESLicenseFile
             - !If
@@ -476,6 +477,48 @@ Resources:
             a-no-operation:
               command: echo "No-Operation" > nul
               waitAfterCompletion: '0'
+        001-ConfigureCW:
+          files:
+            /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json:
+              content: !Sub |
+                {
+                  "agent": {
+                    "run_as_user": "root"
+                  },
+                  "logs": {
+                    "logs_collected": {
+                      "files": {
+                        "collect_list": [
+                          {
+                            "file_path": "/var/log/user-data.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "FS/{instance_id}/user-data.log"
+                          },
+                          {
+                            "file_path": "/var/log/cfn-init.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "FS/{instance_id}/cfn-init.log"
+                          },
+                          {
+                            "file_path": "/var/log/cfn-init-cmd.log",
+                            "log_group_name": "${ESCWLogGroup}",
+                            "log_stream_name": "FS/{instance_id}/cfn-init-cmd.log"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              mode: '000400'
+              owner: root
+              group: root
+          commands:
+            a-stop-cwagent:
+              command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
+              waitAfterCompletion: '30'
+            b-start-cwagent:
+              command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+              waitAfterCompletion: '30'
         010-JoinDomain:
           files:
             '/tmp/JoinTo-Domain-Linux.sh':
@@ -633,6 +676,8 @@ Resources:
               yum -y install python-pip
             - >
               pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+            - >
+              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
             - >
               cp -f /usr/init/redhat/cfn-hup /etc/init.d/
             - |

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -444,6 +444,7 @@ Resources:
     Type: 'AWS::EC2::Volume'
     Properties:
       VolumeType: gp2
+      Encrypted: true
       Size: !Ref FSStorageInGiB
       AvailabilityZone: !Select
         - 0

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -20,6 +20,11 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1p440hhtu)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W9002
+        - W9003
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -334,9 +339,6 @@ Mappings:
       MFES40AMI: ami-0e9d4a9ef3e4fb89a
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
-  GovCloudCondition: !Equals
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
   NamePrefixIaUndefined: !Equals
     - !Ref ESResourceNamePrefix
     - ''
@@ -385,6 +387,13 @@ Resources:
       VpcId: !Ref VPCID
   FSInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for FSInstancePolicy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -396,8 +405,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
       Policies:
         - PolicyDocument:
             Statement:
@@ -667,7 +677,7 @@ Resources:
           - ''
           - - |
               #!/bin/bash -xe
-            - | 
+            - |
               exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
             - >
               for i in 1 2 3 4 5; do rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && break || sleep 2m; done
@@ -683,14 +693,14 @@ Resources:
               chmod 755 /etc/init.d/cfn-hup
               chkconfig --add cfn-hup
             - >-
-              /bin/cfn-init -v --stack 
-            - !Ref 'AWS::StackName' 
+              /bin/cfn-init -v --stack
+            - !Ref 'AWS::StackName'
             - ' --resource FSPrimaryInstance
-              --configsets config 
+              --configsets config
               --region '
             - !Ref 'AWS::Region'
             - |+
-            
+
             - '/bin/cfn-signal -e $? --stack '
             - !Ref 'AWS::StackName'
             - ' --resource FSPrimaryInstance --region '

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -677,7 +677,7 @@ Resources:
             - >
               pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             - >
-              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+              rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
             - >
               cp -f /usr/init/redhat/cfn-hup /etc/init.d/
             - |

--- a/templates/mf-fs-redhat-template.yaml
+++ b/templates/mf-fs-redhat-template.yaml
@@ -25,6 +25,8 @@ Metadata:
       ignore_checks:
         - W9002
         - W9003
+        - W4002
+        - W1020
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -407,7 +409,7 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:

--- a/templates/mf-fs-template.yaml
+++ b/templates/mf-fs-template.yaml
@@ -460,6 +460,7 @@ Resources:
     Type: 'AWS::EC2::Volume'
     Properties:
       VolumeType: gp2
+      Encrypted: true
       Size: !Ref FSStorageInGiB
       AvailabilityZone: !Select
         - 0

--- a/templates/mf-fs-template.yaml
+++ b/templates/mf-fs-template.yaml
@@ -20,6 +20,12 @@ Description: >-
   conditions here (https://www.microfocus.com/about/legal/) for further details.
   (qs-1p440hhtu)"
 Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - E9101
+        - W4002
+        - W1020
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -399,6 +405,13 @@ Resources:
       VpcId: !Ref VPCID
   FSInstanceRole:
     Type: 'AWS::IAM::Role'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyActionWildcard
+          ignore_reasons:
+            - EIAMPolicyActionWildcard: "Wildcard action for bootstrap instance policy allowed by design"
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -410,8 +423,9 @@ Resources:
                 - ec2.amazonaws.com
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyDocument:
             Statement:

--- a/templates/mf-fs-template.yaml
+++ b/templates/mf-fs-template.yaml
@@ -458,6 +458,13 @@ Resources:
         - !Ref FSInstanceRole
   FSPrimaryDataVolume:
     Type: 'AWS::EC2::Volume'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EBSVolumeEncryption
+          ignore_reasons:
+            - EBSVolumeEncryption: "Ignore invalid check"
     Properties:
       VolumeType: gp2
       Encrypted: true


### PR DESCRIPTION
*Issue #, if available:*
Fixed issue where the lambda function name is too long.
Fixed issue where ES instances are unreliable.

*Description of changes:*
Added cloudwatch logging to linux instances.
Added import of Lambda Loggroups so they are deleted when the stack is deleted as well.
Updated allowed instance types for the RDGW instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
